### PR TITLE
1.2.1: a permission Konode asks for is not a feature the browser has

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ All notable changes to Konode. Format loosely follows
   that with an error thrown on the spot rather than a failed promise, which took the whole
   page down with it. Konode now checks that the call is really available before making it.
   Settings opens normally whether or not extension sync is switched on.
+- **A data type could stay switched on after losing its permission, and sync nothing.**
+  History and the extension list need a permission you grant separately, and browsers let
+  you take it back from their own extension settings without telling the extension. When
+  that happened, the type still looked enabled, synced nothing, and left an unreadable
+  error in the log once a cycle. Konode now says which permission is missing and how to
+  restore it, both in Settings and in the sync status, and the rest of your data keeps
+  syncing meanwhile.
 
 ### Fixed: Firefox for Android
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to Konode. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/).
 
-## [Unreleased]
+## [1.2.1] - 2026-08-07
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to Konode. Format loosely follows
 
 ## [Unreleased]
 
+### Fixed
+
+- **The Settings page could open blank.** On a fresh 1.2.0 install, opening Settings showed
+  nothing at all, with `management.getAll is not a function` in the console. 1.2.0 made the
+  extension-list permission optional so the install prompt stays small, and Konode then
+  asked the browser for your extension list before that permission existed. Chrome answers
+  that with an error thrown on the spot rather than a failed promise, which took the whole
+  page down with it. Konode now checks that the call is really available before making it.
+  Settings opens normally whether or not extension sync is switched on.
+
 ### Fixed: Firefox for Android
 
 All four of these come from one detailed field report, and they share one cause: Konode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ it can't.
 
 - **Setup blamed your WebDAV server for a permission it was never asked about.** Firefox
   for Android doesn't implement runtime permission prompts, so the request came back
-  refused with no prompt ever shown — and the wizard reported that as "Konode needs
+  refused with no prompt ever shown, and the wizard reported that as "Konode needs
   permission to reach your WebDAV server". Konode now checks the permissions you already
   hold *before* asking, so a permission granted by hand in Firefox's add-on settings is
   simply accepted. If it still can't ask, it says so, and tells you where to grant it,
@@ -30,7 +30,7 @@ it can't.
 - **The extension could load half-built.** Konode registers its bookmark-change listeners
   when the background script starts. On a browser with no bookmarks API that line threw
   and took the rest of the script down with it, leaving an extension that had started but
-  wasn't finished — which looks like it's working.
+  wasn't finished, which looks like it's working.
 
 ## [1.2.0] - 2026-08-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@ All notable changes to Konode. Format loosely follows
   error in the log once a cycle. Konode now says which permission is missing and how to
   restore it, both in Settings and in the sync status, and the rest of your data keeps
   syncing meanwhile.
+- **One unsupported browser feature no longer takes the rest of Konode with it.** Konode
+  attaches its background listeners the moment it starts, one after another, so a browser
+  that didn't implement one of them stopped the whole sequence there. Everything after it
+  was never set up, on a Konode that had started and looked fine. Each one is now attached
+  on its own, and a browser missing a feature loses only what depends on it. Conflict
+  notifications work the same way: a browser that can't show one still records the conflict
+  and still lets you resolve it in Konode.
 
 ### Fixed: Firefox for Android
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,35 @@
 All notable changes to Konode. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/).
 
+## [Unreleased]
+
+### Fixed: Firefox for Android
+
+All four of these come from one detailed field report, and they share one cause: Konode
+assumed that a permission its manifest asks for is a feature the browser actually has.
+On Firefox for Android that isn't true, and every symptom below is what happens when the
+two disagree. Konode now checks what the browser can really do, and says so plainly where
+it can't.
+
+- **Setup blamed your WebDAV server for a permission it was never asked about.** Firefox
+  for Android doesn't implement runtime permission prompts, so the request came back
+  refused with no prompt ever shown — and the wizard reported that as "Konode needs
+  permission to reach your WebDAV server". Konode now checks the permissions you already
+  hold *before* asking, so a permission granted by hand in Firefox's add-on settings is
+  simply accepted. If it still can't ask, it says so, and tells you where to grant it,
+  instead of telling you that you refused.
+- **The History toggle silently refused to move.** Turning a data type on asks for its
+  optional permission first, and if that came back refused the switch just sprang back
+  with no explanation anywhere. It now says why, on the row you clicked.
+- **Bookmarks failed with a "getTree" error.** Firefox for Android provides no bookmarks
+  API at all. Bookmarks and History are now shown as unavailable there, with the reason,
+  and are skipped by the sync rather than failing it every cycle. Open tabs still sync,
+  and nothing changes for your desktop devices.
+- **The extension could load half-built.** Konode registers its bookmark-change listeners
+  when the background script starts. On a browser with no bookmarks API that line threw
+  and took the rest of the script down with it, leaving an extension that had started but
+  wasn't finished — which looks like it's working.
+
 ## [1.2.0] - 2026-08-04
 
 A full code-review pass over the sync engine, the storage backends and the interface,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,32 @@ All notable changes to Konode. Format loosely follows
 
 ## [1.2.1] - 2026-08-07
 
+### Changed
+
+- **The store listing is easier to find.** The Web Store takes its title from the
+  extension's name, and ours was the bare word "Konode", which matches nothing anyone
+  types. It is now "Konode | Private Bookmark & Tab Sync": the name first, then what it
+  actually does. The title goes through the translation files, so it appears in your own
+  language wherever Konode has been translated.
+
 ### Fixed
 
+- **A crash no longer leaves you with a blank page.** If any screen fails to draw, you now
+  get a short explanation, the error text to quote in a report, and a reload button,
+  instead of an empty window with nothing to go on. Your synced data was never involved in
+  those failures, and the new screen says so, because that is the first thing anyone wants
+  to know.
+- **The "missing on this device" list could quietly hide extensions you really don't have.**
+  Matching a neighbour's extension against your own used the developer's homepage address
+  as one of its signals, and a large share of extensions point that at their source
+  repository. So a single extension of yours homepaged on github.com marked every
+  extension sharing that host as already installed. On a real list of ten genuinely absent
+  extensions, six vanished this way.
+- **The same list dropped anything the browser doesn't call an extension.** Chrome reports
+  apps under their own type names, and the list only ever showed the exact word
+  "extension", so those entries were synced all the way across and then discarded at the
+  last step, with nothing to distinguish them from something never published.
+- **The provider logos in the setup wizard were squashed narrower than they should be.**
 - **The Settings page could open blank.** On a fresh 1.2.0 install, opening Settings showed
   nothing at all, with `management.getAll is not a function` in the console. 1.2.0 made the
   extension-list permission optional so the install prompt stays small, and Konode then

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -105,7 +105,7 @@ shows up as "missing on this device". The list is most exact between same-browse
 
 Firefox for Android runs extensions on GeckoView, which implements a smaller slice of the
 extension APIs than desktop Firefox. Two of those gaps affect Konode directly, and neither
-is something Konode can work around — so it tells you about them instead of failing.
+is something Konode can work around, so it tells you about them instead of failing.
 
 **Bookmarks and History can't be synced there.** Firefox for Android ships no bookmarks
 API and no history API, so an extension has nothing to read or write

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -101,6 +101,28 @@ on the extension's name and on the developer's homepage host instead. That catch
 common cases, but an extension published under different names in the two stores still
 shows up as "missing on this device". The list is most exact between same-browser peers.
 
+## Firefox for Android
+
+Firefox for Android runs extensions on GeckoView, which implements a smaller slice of the
+extension APIs than desktop Firefox. Two of those gaps affect Konode directly, and neither
+is something Konode can work around — so it tells you about them instead of failing.
+
+**Bookmarks and History can't be synced there.** Firefox for Android ships no bookmarks
+API and no history API, so an extension has nothing to read or write
+([bookmarks](https://github.com/mozilla-mobile/fenix/issues/21830)). Konode marks both as
+unavailable in Settings → Data Types and skips them, rather than reporting an error every
+sync for something you can't fix. Open tabs still sync, and your desktop devices carry on
+syncing everything among themselves. Bookmarks you have on Android are not touched.
+
+**"This browser can't show permission prompts."** Firefox for Android doesn't implement
+runtime permission requests
+([bug 1601420](https://bugzilla.mozilla.org/show_bug.cgi?id=1601420)), so when Konode asks
+for access to your WebDAV server, no prompt appears and the request comes back refused. To
+grant it by hand: open Firefox's **Settings → Extensions → Konode → Permissions**, allow
+the permissions there, then return to Konode and try again. Konode checks what you've
+already granted before asking, so once it's allowed there, setup and Test connection go
+through.
+
 ## Starting over
 
 Google Drive has a **Disconnect** button in **Settings → Storage**. GitHub and WebDAV

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "konode",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "MPL-2.0",
   "private": true,
   "type": "module",

--- a/public/_locales/de/messages.json
+++ b/public/_locales/de/messages.json
@@ -380,6 +380,9 @@
   "onb_err_perms_webdav": {
     "message": "Konode braucht die Berechtigung für deinen WebDAV-Server und die gewählten Datentypen. Bitte erteile sie, um fortzufahren."
   },
+  "onb_err_perms_no_prompt": {
+    "message": "Dieser Browser kann keine Berechtigungsdialoge anzeigen, deshalb konnte Konode den benötigten Zugriff nicht anfragen. Erteile ihn auf der Berechtigungsseite von Konode in den Erweiterungseinstellungen deines Browsers und drücke dann erneut auf Fertigstellen."
+  },
   "onb_err_perms_types": {
     "message": "Einige Berechtigungen wurden abgelehnt. Erteile sie oder deaktiviere diese Datentypen, um fortzufahren."
   },

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -433,6 +433,9 @@
   "onb_err_perms_webdav": {
     "message": "Konode needs permission to reach your WebDAV server and the data types you chose. Please allow them to continue."
   },
+  "onb_err_perms_no_prompt": {
+    "message": "This browser can't show permission prompts, so Konode couldn't ask for the access it needs. Grant it on Konode's permissions screen in your browser's extension settings, then press Finish again."
+  },
   "onb_err_perms_types": {
     "message": "Some permissions were declined. Grant them, or turn off those data types, to continue."
   },

--- a/public/_locales/hu/messages.json
+++ b/public/_locales/hu/messages.json
@@ -380,6 +380,9 @@
   "onb_err_perms_webdav": {
     "message": "A Konode-nak engedély kell a WebDAV-szerver eléréséhez és a kiválasztott adattípusokhoz. Engedélyezd őket a folytatáshoz."
   },
+  "onb_err_perms_no_prompt": {
+    "message": "Ez a böngésző nem tud engedélykérő ablakot megjeleníteni, ezért a Konode nem tudta bekérni a szükséges hozzáférést. Engedélyezd a Konode engedélyek képernyőjén, a böngésző kiegészítőbeállításai között, majd nyomd meg újra a Befejezés gombot."
+  },
   "onb_err_perms_types": {
     "message": "Néhány engedélyt elutasítottál. A folytatáshoz engedélyezd őket, vagy kapcsold ki azokat az adattípusokat."
   },

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -3,7 +3,7 @@
   "name": "__MSG_extension_name__",
   "short_name": "Konode",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAot/n/1Oj+Rz2Zr+ZJaaC7Gp7AsmWzrDA2n7e+1ha8iuMjTQQfSyBAE7p9plx8I/+/uqnqfIT7bQg3V1chIaOAAzgmCI8CWbaC7yG+xKTZgreu4Fo1sv+qoPls4Wgvstpggv+6YartZk1YxU1VVQsUasWUTe8aGeEO7vLGi+OXJKl80GykFxOQ+uZPtoOYWTUJgtkSreVa/CZBOx1tW+3+Oy0IHO/9ajim0eXme9X7Whg/raER+RqOMBLkE0uS2cdSi9h0ikWD9W8SUKwd1/TUFSL7SnSOile9JLAYJStWWQA228dOu869dwWWpcE5I/Xw9TJIJ3YIlrB4GtaZTZPAwIDAQAB",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "__MSG_extension_description__",
   "default_locale": "en",
   "icons": {

--- a/src/background/service-worker.ts
+++ b/src/background/service-worker.ts
@@ -84,10 +84,18 @@ function ensureInit(): Promise<void> {
 
 // ─── Badge ────────────────────────────────────────────────────────────────
 
+/** The toolbar badge is decoration, and not every browser has one to draw on — mobile
+ *  builds in particular. A throw here used to travel up through `broadcastState`, which
+ *  is called from the sync path, so a missing badge could take a working sync down with
+ *  it. Nothing about the sync depends on this succeeding. */
 function updateBadge(status: string): void {
   const key = status as keyof typeof BADGE_COLORS;
-  browser.action.setBadgeBackgroundColor({ color: BADGE_COLORS[key] ?? BADGE_COLORS.idle });
-  browser.action.setBadgeText({ text: BADGE_TEXT[key] ?? "" });
+  try {
+    browser.action.setBadgeBackgroundColor({ color: BADGE_COLORS[key] ?? BADGE_COLORS.idle });
+    browser.action.setBadgeText({ text: BADGE_TEXT[key] ?? "" });
+  } catch (e) {
+    logger.debug("updateBadge", `This browser wouldn't take a toolbar badge: ${e instanceof Error ? e.message : e}`);
+  }
 }
 
 /** Update the toolbar and push the state to any open popup/options view.

--- a/src/background/service-worker.ts
+++ b/src/background/service-worker.ts
@@ -10,6 +10,7 @@ import { logger, setLoggerDebug } from "@/lib/utils/logger";
 import { BADGE_COLORS, BADGE_TEXT, STATE_UPDATE } from "@/lib/constants";
 import { browser } from "@/lib/utils/ext";
 import { ensureSyncAlarm, SYNC_ALARM, BOOKMARK_ALARM } from "@/lib/utils/alarms";
+import { eventPresent } from "@/lib/utils/capabilities";
 
 // ─── State ────────────────────────────────────────────────────────────────
 
@@ -270,7 +271,33 @@ async function handleMessage(message: ExtensionMessage): Promise<ExtensionRespon
 
 // ─── Alarm Handler ────────────────────────────────────────────────────────
 
-browser.alarms.onAlarm.addListener(async (alarm) => {
+/**
+ * Attach one top-level listener, and survive a browser that hasn't got the event.
+ *
+ * Every registration in this file runs at module scope, because MV3 requires listeners to
+ * be attached on every worker load. That makes the file one long fuse: the FIRST missing
+ * event throws, and everything below it never runs, including `ensureInit()` at the very
+ * bottom. The result is an extension that started, registered some of its listeners, and
+ * looks alive. Konode has already been bitten by exactly this once, through the bookmark
+ * listeners on a browser with no bookmarks API.
+ *
+ * Not hypothetical beyond that either: Orion implements roughly 70% of the extension APIs,
+ * so "this engine is missing an event we assumed" is a normal Tuesday, not an edge case.
+ * A missing event costs the feature that needs it. It must not cost the ones that don't.
+ */
+function on(ns: string, event: string, register: () => void): void {
+  if (!eventPresent(ns, event)) {
+    logger.info("ServiceWorker", `This browser has no ${ns}.${event} — that listener is not registered`);
+    return;
+  }
+  try {
+    register();
+  } catch (e) {
+    logger.warn("ServiceWorker", `Registering ${ns}.${event} failed: ${e instanceof Error ? e.message : e}`);
+  }
+}
+
+on("alarms", "onAlarm", () => browser.alarms.onAlarm.addListener(async (alarm) => {
   await ensureInit();
   if (!syncEngine) return;
   if (alarm.name === SYNC_ALARM) {
@@ -287,21 +314,21 @@ browser.alarms.onAlarm.addListener(async (alarm) => {
       await syncEngine.sync(["bookmarks"]);
     }
   }
-});
+}));
 
 // ─── Lifecycle ────────────────────────────────────────────────────────────
 
-browser.runtime.onInstalled.addListener(async (details) => {
+on("runtime", "onInstalled", () => browser.runtime.onInstalled.addListener(async (details) => {
   if (details.reason === "install") {
     logger.event("Install", "First install, opening onboarding");
     browser.tabs.create({ url: browser.runtime.getURL("onboarding.html") });
   }
   await ensureInit();
-});
+}));
 
-browser.runtime.onStartup.addListener(async () => {
+on("runtime", "onStartup", () => browser.runtime.onStartup.addListener(async () => {
   await ensureInit();
-});
+}));
 
 // Register bookmark-change listeners once, synchronously, at the top level —
 // MV3 requires event listeners to be attached on every worker load, and doing

--- a/src/lib/handlers/bookmarks-handler.ts
+++ b/src/lib/handlers/bookmarks-handler.ts
@@ -14,12 +14,14 @@ import {
 import { defaultOtherRootId, matchLocalRoot, matchLocalRootEx, rootKind } from "@/lib/utils/bookmark-roots";
 import { canonicalUrlKey } from "@/lib/utils/url";
 import { browser } from "@/lib/utils/ext";
+import { assertDataTypeApi, eventPresent } from "@/lib/utils/capabilities";
 
 type BookmarkNode = chrome.bookmarks.BookmarkTreeNode;
 
 // ─── Read ─────────────────────────────────────────────────────────────────
 
 export async function exportBookmarks(): Promise<SyncBookmark[]> {
+  assertDataTypeApi("bookmarks");
   const tree = await browser.bookmarks.getTree();
   return tree.map(mapNode);
 }
@@ -388,6 +390,7 @@ export async function importBookmarks(
   // `blocked` is how many local bookmarks the guard refused to remove this merge.
   onBulkBlocked?: (blocked: number) => void
 ): Promise<void> {
+  assertDataTypeApi("bookmarks");
   const {
     tree, tombstones: remoteTombstones, moves: remoteMoves = [],
     folderMoves: remoteFolderMoves = [], titles: remoteTitles = [],
@@ -990,6 +993,7 @@ function pruneEmptyFolders(tree: SyncBookmark[]): SyncBookmark[] {
  *  Folders are materialized lazily (only when a restored bookmark lands under them),
  *  so an empty folder from the snapshot isn't recreated. Returns the count added. */
 export async function restoreBookmarks(tree: SyncBookmark[]): Promise<number> {
+  assertDataTypeApi("bookmarks");
   importing = true;
   try {
     const snapUrls = new Set(
@@ -1050,6 +1054,15 @@ export async function restoreBookmarks(tree: SyncBookmark[]): Promise<number> {
 export type BookmarkChangeCallback = () => void;
 
 export function registerBookmarkListeners(onChange: BookmarkChangeCallback): void {
+  // The background script calls this at the TOP LEVEL, because MV3 requires listeners to
+  // be attached on every worker load. So on a browser with no bookmarks API this line
+  // threw during module evaluation and took the rest of the file down with it — the
+  // extension came up half-built, with whatever had already registered still working.
+  // That is the worst possible failure shape: it looks like the extension works.
+  if (!eventPresent("bookmarks", "onCreated")) {
+    logger.info("BookmarkListeners", "This browser has no bookmarks API — bookmark-change listeners not registered");
+    return;
+  }
   browser.bookmarks.onCreated.addListener(onChange);
   browser.bookmarks.onChanged.addListener((id, changeInfo) => {
     // A URL edit is a delete(old)+add(new) in the URL-keyed sync model — record a

--- a/src/lib/handlers/extensions-handler.ts
+++ b/src/lib/handlers/extensions-handler.ts
@@ -2,6 +2,7 @@ import type { SyncExtension } from "@/lib/types";
 import { logger } from "@/lib/utils/logger";
 import { browser, currentStore } from "@/lib/utils/ext";
 import { storeUrlFor } from "@/lib/utils/extensions-match";
+import { assertDataTypeApi } from "@/lib/utils/capabilities";
 
 // Legacy webstore URL: Chrome redirects /detail/<id> to the correct listing.
 // The new chromewebstore.google.com/detail/<id> form needs a slug we don't have.
@@ -13,6 +14,7 @@ import { storeUrlFor } from "@/lib/utils/extensions-match";
  * Filters out: themes, built-in Chrome extensions, and Konode itself.
  */
 export async function exportExtensions(): Promise<SyncExtension[]> {
+  assertDataTypeApi("extensions");
   const extensions = await browser.management.getAll();
   const selfId = browser.runtime.id;
   const store = currentStore();

--- a/src/lib/handlers/history-handler.ts
+++ b/src/lib/handlers/history-handler.ts
@@ -7,6 +7,7 @@ import {
   clearRejectedHistoryUrls, getVisitTimeSupport, setVisitTimeSupport,
 } from "@/lib/utils/storage";
 import { browser } from "@/lib/utils/ext";
+import { assertDataTypeApi } from "@/lib/utils/capabilities";
 
 const EXPORT_MAX_RESULTS = 5000;
 
@@ -55,6 +56,7 @@ const IMPORT_CONCURRENCY = 16;
 // ─── Export ──────────────────────────────────────────────────────────────
 
 export async function exportHistory(daysLimit = 30): Promise<SyncHistoryItem[]> {
+  assertDataTypeApi("history");
   const startTime = Date.now() - daysLimit * 24 * 60 * 60 * 1000;
 
   const items = await browser.history.search({
@@ -118,6 +120,7 @@ export async function exportHistory(daysLimit = 30): Promise<SyncHistoryItem[]> 
 // ─── Import (merge remote history) ───────────────────────────────────────
 
 export async function importHistory(items: SyncHistoryItem[]): Promise<void> {
+  assertDataTypeApi("history");
   // NOTE: on Chrome, history.addUrl records a visit only at the *current* time
   // (its API takes no visitTime), so the original lastVisitTime is lost and
   // visitCount can't be restored at all — history restore is lossy there

--- a/src/lib/handlers/tabs-handler.ts
+++ b/src/lib/handlers/tabs-handler.ts
@@ -4,6 +4,7 @@ type TabInfo = { url: string; title?: string; pinned: boolean; favIconUrl?: stri
 import { logger } from "@/lib/utils/logger";
 import { isSafeContentUrl, isSensitiveUrl } from "@/lib/utils/url";
 import { browser } from "@/lib/utils/ext";
+import { assertDataTypeApi } from "@/lib/utils/capabilities";
 
 // ─── Export Current Tabs ──────────────────────────────────────────────────
 
@@ -19,6 +20,7 @@ import { browser } from "@/lib/utils/ext";
  * so this was the most sensitive data we handled, uploaded for no benefit at all.
  */
 export async function exportCurrentTabs(): Promise<TabInfo[]> {
+  assertDataTypeApi("sessions");
   const tabs = await browser.tabs.query({});
   const publishable = tabs.filter((t) => isSafeContentUrl(t.url) && !isSensitiveUrl(t.url));
   // Debug-only (never the audit log): a count, never the URLs themselves.
@@ -49,6 +51,7 @@ export async function exportSession(label?: string): Promise<SyncSession> {
 // ─── Import (open tabs from a session) ────────────────────────────────────
 
 export async function importSession(session: SyncSession): Promise<void> {
+  assertDataTypeApi("sessions");
   // Never open a non-web URL from a remote packet (javascript:/data:/file: are
   // an injection/exfiltration vector); only http(s) tabs are restored.
   const openable = session.tabs.filter((t) => {

--- a/src/lib/sync/conflict-resolver.ts
+++ b/src/lib/sync/conflict-resolver.ts
@@ -6,6 +6,7 @@ import type {
 } from "@/lib/types";
 import { logger } from "@/lib/utils/logger";
 import { browser } from "@/lib/utils/ext";
+import { apiPresent } from "@/lib/utils/capabilities";
 
 // ─── Conflict Resolver ────────────────────────────────────────────────────
 
@@ -102,6 +103,13 @@ export function orderPeersByTime(packets: SyncPacket[]): SyncPacket[] {
 // ─── Notify helper ───────────────────────────────────────────────────────
 
 export function notifyConflict(dataType: DataType): void {
+  // A conflict is still recorded and still resolvable in the UI without this. Losing the
+  // desktop notification is a small thing; losing the SYNC because the browser doesn't
+  // implement notifications would not be, and this is called from inside the sync.
+  if (!apiPresent("notifications", "create")) {
+    logger.info("notifyConflict", `This browser has no notifications API, so the ${dataType} conflict is only shown in Konode`);
+    return;
+  }
   browser.notifications.create(`conflict-${Date.now()}`, {
     type: "basic",
     iconUrl: "icons/icon48.png",

--- a/src/lib/sync/sync-engine.test.ts
+++ b/src/lib/sync/sync-engine.test.ts
@@ -433,6 +433,36 @@ describe("SyncEngine — one data type's failure must not abort the others", () 
     expect(await priv(engine).syncAllTypes(["bookmarks"], backend, DEFAULT_STATE)).toEqual([]);
   });
 
+  it("REPORTS a type whose optional permission is gone, rather than skipping it quietly", async () => {
+    // The other half of the check above, and the opposite answer. Here the browser can do
+    // it and the permission is simply missing, which is the user's to fix. Reported on
+    // 1.2.0 as a raw "undefined is not an object (evaluating 'u.history.search')" once a
+    // cycle; silence would be no better, because the type sits there enabled and syncs
+    // nothing. `history` is undefined AND not granted, which is exactly that state.
+    const engine = makeEngine();
+    const backend = new FakeBackend();
+    // An empty bookmark payload is deliberately never uploaded, so seed one: this test
+    // is about bookmarks still going out, and it has to have something to send.
+    await chrome.bookmarks.create({ parentId: "1", title: "A", url: "https://a.com" });
+    const history = chrome.history;
+    const permissions = chrome.permissions;
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    delete (chrome as any).history;
+    (chrome as any).permissions = { contains: () => Promise.resolve(false), request: () => Promise.resolve(false) };
+    try {
+      const problems = await priv(engine).syncAllTypes(["history", "bookmarks"], backend, DEFAULT_STATE);
+      expect(problems).toHaveLength(1);
+      expect(problems[0]).toContain("history");
+      expect(problems[0]).toContain("permission");
+      // The point of reporting rather than throwing: bookmarks still goes out.
+      expect(backend.uploads.map((u) => u.data_type)).toEqual(["bookmarks"]);
+    } finally {
+      (chrome as any).history = history;
+      (chrome as any).permissions = permissions;
+      /* eslint-enable @typescript-eslint/no-explicit-any */
+    }
+  });
+
   it("skips a type this browser has no API for, and does NOT call it an error", async () => {
     // Firefox for Android has no bookmarks API, so `bookmarks` can never produce a byte
     // there. Reporting that once a minute would pin the extension to a red error state

--- a/src/lib/sync/sync-engine.test.ts
+++ b/src/lib/sync/sync-engine.test.ts
@@ -432,6 +432,26 @@ describe("SyncEngine — one data type's failure must not abort the others", () 
 
     expect(await priv(engine).syncAllTypes(["bookmarks"], backend, DEFAULT_STATE)).toEqual([]);
   });
+
+  it("skips a type this browser has no API for, and does NOT call it an error", async () => {
+    // Firefox for Android has no bookmarks API, so `bookmarks` can never produce a byte
+    // there. Reporting that once a minute would pin the extension to a red error state
+    // forever over something the user cannot fix — and bury the real failures under it.
+    // Settings is where this is explained, next to the toggle itself.
+    const engine = makeEngine();
+    const backend = new FakeBackend();
+    const bookmarks = chrome.bookmarks;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (chrome as any).bookmarks;
+    try {
+      const problems = await priv(engine).syncAllTypes(["bookmarks", "sessions"], backend, DEFAULT_STATE);
+      expect(problems).toEqual([]);
+      expect(backend.uploads.map((u) => u.data_type)).not.toContain("bookmarks");
+    } finally {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (chrome as any).bookmarks = bookmarks;
+    }
+  });
 });
 
 describe("SyncEngine.syncType — a tab-less session is not published", () => {

--- a/src/lib/sync/sync-engine.ts
+++ b/src/lib/sync/sync-engine.ts
@@ -8,7 +8,7 @@ import { exportBookmarkPayload, importBookmarks } from "@/lib/handlers/bookmarks
 import { exportSession, importSession } from "@/lib/handlers/tabs-handler";
 import { exportHistory, importHistory } from "@/lib/handlers/history-handler";
 import { exportExtensions } from "@/lib/handlers/extensions-handler";
-import { dataTypeApiPresent, unsupportedReason } from "@/lib/utils/capabilities";
+import { dataTypeAvailability, unsupportedReason } from "@/lib/utils/capabilities";
 import {
   getState,
   setState,
@@ -329,18 +329,34 @@ export class SyncEngine {
   ): Promise<string[]> {
     const errors: string[] = [];
 
-    // Drop types this browser has no API for BEFORE anything else touches them.
+    // Sort out the types whose API isn't there BEFORE anything else touches them — and
+    // note that "isn't there" has two very different meanings that need opposite handling.
     //
-    // Not an error, and deliberately not reported as one: "Firefox for Android has no
-    // bookmarks API" is a standing fact about the device, not something that went wrong
-    // this cycle. Recording it in `last_error` would pin the extension to a red error
-    // state forever, every minute, for a condition the user cannot fix — while burying
-    // the real failures underneath it. The Settings screen is where this belongs, and it
-    // says so next to the toggle itself.
+    // The browser DOESN'T IMPLEMENT IT. "Firefox for Android has no bookmarks API" is a
+    // standing fact about the device, not something that went wrong this cycle. Recording
+    // it in `last_error` would pin the extension to a red error state forever, every
+    // minute, for a condition the user cannot fix, while burying the real failures
+    // underneath it. Skipped quietly; Settings is where it's explained, next to the toggle.
+    //
+    // The PERMISSION IS GONE. The type is switched on, the browser can do it, and the
+    // optional permission has simply not been granted (or was revoked in the browser's own
+    // extension settings, which no extension is told about). That IS the user's to fix, and
+    // staying quiet about it would be worse than the raw crash it replaces: the type would
+    // sit there enabled and never sync a thing. So it's reported, and it says how to fix it.
+    //
+    // Getting these two backwards is exactly the bug a user hit on 1.2.0: history and
+    // extensions were enabled with their permissions missing, so every cycle logged a raw
+    // "undefined is not an object (evaluating 'u.history.search')" and nothing said why.
     const runnable: DataType[] = [];
     for (const t of types) {
-      if (dataTypeApiPresent(t)) runnable.push(t);
-      else logger.info("SyncEngine", `Skipping ${t}: ${unsupportedReason(t)}`);
+      const state = await dataTypeAvailability(t);
+      if (state.state === "ready") runnable.push(t);
+      else if (state.state === "unsupported") logger.info("SyncEngine", `Skipping ${t}: ${unsupportedReason(t)}`);
+      else {
+        const msg = `${t}: Konode doesn't have the "${state.permission}" permission any more, so this can't sync. Open Settings, Data Types, and switch it off and on again to restore it.`;
+        logger.warn("SyncEngine", msg);
+        errors.push(msg);
+      }
     }
 
     await this.findOwnMissingFiles(backend, runnable);

--- a/src/lib/sync/sync-engine.ts
+++ b/src/lib/sync/sync-engine.ts
@@ -8,6 +8,7 @@ import { exportBookmarkPayload, importBookmarks } from "@/lib/handlers/bookmarks
 import { exportSession, importSession } from "@/lib/handlers/tabs-handler";
 import { exportHistory, importHistory } from "@/lib/handlers/history-handler";
 import { exportExtensions } from "@/lib/handlers/extensions-handler";
+import { dataTypeApiPresent, unsupportedReason } from "@/lib/utils/capabilities";
 import {
   getState,
   setState,
@@ -327,8 +328,23 @@ export class SyncEngine {
     state: SyncState
   ): Promise<string[]> {
     const errors: string[] = [];
-    await this.findOwnMissingFiles(backend, types);
-    for (const dataType of types) {
+
+    // Drop types this browser has no API for BEFORE anything else touches them.
+    //
+    // Not an error, and deliberately not reported as one: "Firefox for Android has no
+    // bookmarks API" is a standing fact about the device, not something that went wrong
+    // this cycle. Recording it in `last_error` would pin the extension to a red error
+    // state forever, every minute, for a condition the user cannot fix — while burying
+    // the real failures underneath it. The Settings screen is where this belongs, and it
+    // says so next to the toggle itself.
+    const runnable: DataType[] = [];
+    for (const t of types) {
+      if (dataTypeApiPresent(t)) runnable.push(t);
+      else logger.info("SyncEngine", `Skipping ${t}: ${unsupportedReason(t)}`);
+    }
+
+    await this.findOwnMissingFiles(backend, runnable);
+    for (const dataType of runnable) {
       try {
         await this.syncType(dataType, backend, state);
       } catch (err) {

--- a/src/lib/utils/capabilities.test.ts
+++ b/src/lib/utils/capabilities.test.ts
@@ -67,6 +67,17 @@ describe("reading the API surface", () => {
     expect(dataTypeApiPresent("history")).toBe(false);
   });
 
+  it("says no to Chrome's restricted management namespace", () => {
+    // The exact shape behind a reported blank Settings page. Chrome does NOT hide
+    // `chrome.management` when the optional permission isn't granted: it hands back an
+    // object carrying only getSelf/uninstallSelf. So `management.getAll` is not a
+    // function, and calling it throws synchronously, before there is any promise for a
+    // `.catch()` to catch. Inside a React effect that unmounts the tree and the page
+    // renders blank. A namespace-level check would have answered "present" here.
+    replace("management", { getSelf: () => Promise.resolve({}), uninstallSelf: () => Promise.resolve() });
+    expect(dataTypeApiPresent("extensions")).toBe(false);
+  });
+
   it("says yes when the method is really there", () => {
     expect(dataTypeApiPresent("bookmarks")).toBe(true);
     expect(dataTypeApiPresent("sessions")).toBe(true);

--- a/src/lib/utils/capabilities.test.ts
+++ b/src/lib/utils/capabilities.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  apiPresent, eventPresent, dataTypeApiPresent, dataTypeAvailability, allDataTypeAvailability,
+  assertDataTypeApi, ensurePermission, hasPermission, isAndroid, resetCapabilityCache,
+} from "@/lib/utils/capabilities";
+import { registerBookmarkListeners, exportBookmarks } from "@/lib/handlers/bookmarks-handler";
+
+/**
+ * These tests exist because of one field report, and every case below is a line from it.
+ *
+ * A user set Konode up on Fennec (Firefox for Android). The wizard told them their WebDAV
+ * server had refused permission — it hadn't; the browser cannot show a permission prompt
+ * at all. The History toggle would not move, and said nothing. Bookmarks failed with
+ * "getTree", because that browser ships no bookmarks API.
+ *
+ * The shared cause is a browser whose manifest permissions and whose actual API surface
+ * disagree, so the fake browser is edited per test to model exactly that. Everything is
+ * restored afterwards: `test/setup.ts` rebuilds the bookmark/history/tab stores between
+ * tests, but a namespace deleted off `chrome` would stay deleted for the whole file.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const api = chrome as any;
+
+let saved: Record<string, unknown> = {};
+function replace(ns: string, value: unknown): void {
+  if (!(ns in saved)) saved[ns] = api[ns];
+  if (value === undefined) delete api[ns];
+  else api[ns] = value;
+}
+
+beforeEach(() => {
+  saved = {};
+  resetCapabilityCache();
+});
+
+afterEach(() => {
+  for (const [ns, value] of Object.entries(saved)) api[ns] = value;
+  saved = {};
+  resetCapabilityCache();
+});
+
+/** Model a browser that grants everything / nothing, and record what was asked for. */
+function permissions(opts: { held?: boolean; request?: () => Promise<boolean> } = {}) {
+  const requests: unknown[] = [];
+  replace("permissions", {
+    contains: () => Promise.resolve(opts.held ?? false),
+    request: (req: unknown) => {
+      requests.push(req);
+      return (opts.request ?? (() => Promise.resolve(false)))();
+    },
+  });
+  return requests;
+}
+
+describe("reading the API surface", () => {
+  it("says no to a namespace the browser doesn't have at all", () => {
+    replace("bookmarks", undefined);
+    expect(apiPresent("bookmarks", "getTree")).toBe(false);
+    expect(dataTypeApiPresent("bookmarks")).toBe(false);
+  });
+
+  it("says no to a namespace that exists but is missing the method", () => {
+    // A stub object is exactly as unusable as no object, and reporting it as present is
+    // how a call gets made that can only throw.
+    replace("history", { search: undefined, addUrl: () => Promise.resolve() });
+    expect(dataTypeApiPresent("history")).toBe(false);
+  });
+
+  it("says yes when the method is really there", () => {
+    expect(dataTypeApiPresent("bookmarks")).toBe(true);
+    expect(dataTypeApiPresent("sessions")).toBe(true);
+  });
+
+  it("recognises an event, which is an object rather than a function", () => {
+    // The distinction is load-bearing: checking an event with the function test answers
+    // "missing" for every event that exists, which would silently unregister listeners
+    // on a perfectly capable browser.
+    expect(apiPresent("bookmarks", "onCreated")).toBe(false);
+    expect(eventPresent("bookmarks", "onCreated")).toBe(true);
+    expect(eventPresent("bookmarks", "onNothingLikeThis")).toBe(false);
+  });
+});
+
+describe("whether a data type can sync here", () => {
+  it("is ready when the API is present", async () => {
+    expect(await dataTypeAvailability("bookmarks")).toEqual({ state: "ready" });
+  });
+
+  it("is unsupported — not 'ask for a permission' — when bookmarks are missing", async () => {
+    // `bookmarks` is a REQUIRED manifest permission, so it is already held and there is
+    // nothing left to request. Firefox for Android accepts the permission and ships no
+    // API behind it (mozilla-mobile/fenix#21830).
+    replace("bookmarks", undefined);
+    expect(await dataTypeAvailability("bookmarks")).toEqual({ state: "unsupported" });
+  });
+
+  it("is unsupported when the permission IS held and the API still isn't there", async () => {
+    replace("history", undefined);
+    permissions({ held: true });
+    expect(await dataTypeAvailability("history")).toEqual({ state: "unsupported" });
+  });
+
+  it("is a missing permission when the permission is what's missing", async () => {
+    // Same missing `browser.history`, opposite meaning: on Chrome an optional-permission
+    // API is undefined until it is granted, so only the permission check tells the two
+    // apart — and they need opposite treatment in the UI.
+    replace("history", undefined);
+    permissions({ held: false });
+    expect(await dataTypeAvailability("history")).toEqual({ state: "needs-permission", permission: "history" });
+  });
+
+  it("answers for all four types at once", async () => {
+    replace("bookmarks", undefined);
+    replace("management", undefined);
+    permissions({ held: true });
+    const all = await allDataTypeAvailability();
+    expect(all.bookmarks.state).toBe("unsupported");
+    expect(all.extensions.state).toBe("unsupported");
+    expect(all.history.state).toBe("ready");
+    expect(all.sessions.state).toBe("ready");
+  });
+});
+
+describe("what a handler throws when the API isn't there", () => {
+  it("names the browser instead of surfacing a TypeError", async () => {
+    replace("bookmarks", undefined);
+    // The old failure was "Cannot read properties of undefined (reading 'getTree')",
+    // which reads as a crash in Konode rather than a limit of the browser.
+    await expect(exportBookmarks()).rejects.toThrow(/Firefox for Android/);
+    expect(() => assertDataTypeApi("bookmarks")).toThrow(/bookmarks can't sync here/);
+  });
+
+  it("stays quiet when the API is present", () => {
+    expect(() => assertDataTypeApi("bookmarks")).not.toThrow();
+  });
+});
+
+describe("registering bookmark listeners", () => {
+  it("does not throw on a browser with no bookmarks API", () => {
+    // The background script calls this at the top level, so a throw here took out the
+    // rest of the module and left the extension half-built — working enough to look fine.
+    replace("bookmarks", undefined);
+    expect(() => registerBookmarkListeners(() => {})).not.toThrow();
+  });
+});
+
+describe("obtaining a permission", () => {
+  it("never prompts for a permission that is already held", async () => {
+    // THE Fennec fix. Firefox for Android has no prompt, but it does let the user grant
+    // permissions by hand in the add-on's own settings — and the reporter had done
+    // exactly that. Asking request() about it would still answer false and send them
+    // round the same dead end again.
+    const requests = permissions({ held: true, request: () => Promise.resolve(false) });
+    expect(await ensurePermission({ origins: ["https://cloud.example.com/*"] })).toBe("granted");
+    expect(requests).toEqual([]);
+  });
+
+  it("grants when the prompt is accepted", async () => {
+    permissions({ held: false, request: () => Promise.resolve(true) });
+    expect(await ensurePermission({ permissions: ["history"] })).toBe("granted");
+  });
+
+  it("reports a refusal as a refusal on a browser that can prompt", async () => {
+    permissions({ held: false, request: () => Promise.resolve(false) });
+    expect(await ensurePermission({ permissions: ["history"] })).toBe("denied");
+  });
+
+  it("reports 'cannot-prompt' on Android rather than blaming the user", async () => {
+    // permissions.request() is unimplemented on GeckoView (bugzilla 1601420): it resolves
+    // false whatever the user would have said. Calling that a refusal is what produced
+    // "Konode needs permission to reach your WebDAV server" with no prompt in sight.
+    replace("runtime", { ...api.runtime, getPlatformInfo: () => Promise.resolve({ os: "android" }) });
+    permissions({ held: false, request: () => Promise.resolve(false) });
+    expect(await ensurePermission({ origins: ["https://cloud.example.com/*"] })).toBe("cannot-prompt");
+  });
+
+  it("treats a THROWING request the same as a false one", async () => {
+    replace("runtime", { ...api.runtime, getPlatformInfo: () => Promise.resolve({ os: "android" }) });
+    permissions({ held: false, request: () => Promise.reject(new Error("not implemented")) });
+    expect(await ensurePermission({ permissions: ["tabs"] })).toBe("cannot-prompt");
+  });
+
+  it("believes what we HOLD over what request() answered", async () => {
+    // A browser that grants the permission and then reports false about it is not
+    // hypothetical enough to ignore, and the second check costs one call on the only
+    // path that already failed.
+    let granted = false;
+    replace("permissions", {
+      contains: () => Promise.resolve(granted),
+      request: () => { granted = true; return Promise.resolve(false); },
+    });
+    expect(await ensurePermission({ permissions: ["history"] })).toBe("granted");
+  });
+
+  it("treats an unanswerable contains() as a no rather than an exception", async () => {
+    replace("permissions", { contains: () => Promise.reject(new Error("nope")), request: () => Promise.resolve(false) });
+    expect(await hasPermission({ permissions: ["history"] })).toBe(false);
+  });
+});
+
+describe("identifying the platform", () => {
+  it("asks the browser, not the user agent", async () => {
+    const getPlatformInfo = vi.fn(() => Promise.resolve({ os: "android" }));
+    replace("runtime", { ...api.runtime, getPlatformInfo });
+    expect(await isAndroid()).toBe(true);
+    // Cached — the answer cannot change within a page's lifetime, and the callers are
+    // click handlers that must not spend an extra round trip before request().
+    expect(await isAndroid()).toBe(true);
+    expect(getPlatformInfo).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to the user agent when the browser won't say", async () => {
+    replace("runtime", { ...api.runtime, getPlatformInfo: () => Promise.reject(new Error("unsupported")) });
+    const ua = globalThis.navigator.userAgent;
+    Object.defineProperty(globalThis.navigator, "userAgent", { value: "Mozilla/5.0 (Android 14; Mobile)", configurable: true });
+    try {
+      expect(await isAndroid()).toBe(true);
+    } finally {
+      Object.defineProperty(globalThis.navigator, "userAgent", { value: ua, configurable: true });
+    }
+  });
+});

--- a/src/lib/utils/capabilities.test.ts
+++ b/src/lib/utils/capabilities.test.ts
@@ -4,6 +4,7 @@ import {
   assertDataTypeApi, ensurePermission, hasPermission, isAndroid, resetCapabilityCache,
 } from "@/lib/utils/capabilities";
 import { registerBookmarkListeners, exportBookmarks } from "@/lib/handlers/bookmarks-handler";
+import { notifyConflict } from "@/lib/sync/conflict-resolver";
 
 /**
  * These tests exist because of one field report, and every case below is a line from it.
@@ -147,12 +148,21 @@ describe("what a handler throws when the API isn't there", () => {
   });
 });
 
-describe("registering bookmark listeners", () => {
-  it("does not throw on a browser with no bookmarks API", () => {
+describe("carrying on without an API", () => {
+  it("registers no bookmark listeners on a browser with no bookmarks API", () => {
     // The background script calls this at the top level, so a throw here took out the
     // rest of the module and left the extension half-built — working enough to look fine.
     replace("bookmarks", undefined);
     expect(() => registerBookmarkListeners(() => {})).not.toThrow();
+  });
+
+  it("skips the conflict notification rather than failing the sync", () => {
+    // notifyConflict is called from inside a sync. The conflict is recorded and
+    // resolvable in the UI either way, so a browser without notifications should lose
+    // the toast and nothing else. Orion implements roughly 70% of the extension APIs,
+    // which makes "this engine hasn't got that one" ordinary rather than exotic.
+    replace("notifications", undefined);
+    expect(() => notifyConflict("bookmarks")).not.toThrow();
   });
 });
 

--- a/src/lib/utils/capabilities.ts
+++ b/src/lib/utils/capabilities.ts
@@ -1,0 +1,249 @@
+/**
+ * What the browser Konode is running in can actually DO — as opposed to what its
+ * manifest says it may do.
+ *
+ * The two are not the same thing, and the gap is not theoretical. Firefox for Android
+ * accepts `"permissions": ["bookmarks"]` at install time and then ships no bookmarks API
+ * at all: the permission is granted, `browser.bookmarks` is `undefined`, and every call
+ * into it is a TypeError. The same holds for `history`. A field report from a Fennec user
+ * showed exactly the shape that produces — bookmarks failing with "getTree", the History
+ * toggle refusing to turn on, and the setup wizard blaming the WebDAV server for a
+ * permission problem that had nothing to do with WebDAV.
+ *
+ * So: ASK the browser, don't assume from the manifest, and don't assume from the engine
+ * name either. A capability check answers correctly for browsers that don't exist yet;
+ * a `/Android/` sniff only answers for the ones we thought of.
+ *
+ * Sources for the platform facts referenced here:
+ *   - bookmarks API missing on Firefox for Android — mozilla-mobile/fenix#21830
+ *   - history API missing on Firefox for Android — Rayquaza01/HistoryCleaner#22
+ *   - permissions.request() unimplemented on GeckoView — bugzilla 1601420,
+ *     mdn/browser-compat-data#13299
+ */
+import { browser } from "@/lib/utils/ext";
+import type { DataType } from "@/lib/types";
+
+/**
+ * The optional permission a data type needs, for the types that need one.
+ *
+ * `bookmarks` is absent on purpose — it is a REQUIRED manifest permission, always held,
+ * never requested. That absence is load-bearing in `dataTypeAvailability` below.
+ */
+export const PERMISSION_FOR_TYPE: Partial<Record<DataType, string>> = {
+  history: "history",
+  sessions: "tabs",
+  extensions: "management",
+};
+
+/**
+ * The namespace and one method each data type cannot work without.
+ *
+ * One method rather than the whole namespace: a browser that exposes a stub `bookmarks`
+ * object with nothing on it is just as unusable as one that exposes nothing, and the
+ * check should say so either way.
+ */
+const API_FOR_TYPE: Record<DataType, readonly [ns: string, method: string]> = {
+  bookmarks: ["bookmarks", "getTree"],
+  history: ["history", "search"],
+  sessions: ["tabs", "query"],
+  extensions: ["management", "getAll"],
+};
+
+/** Does this browser implement `browser.<ns>.<method>()`? */
+export function apiPresent(ns: string, method: string): boolean {
+  // Deliberately loose: `browser` is typed as `typeof chrome`, which declares every
+  // namespace as always present. That type is a promise about the API surface, not a
+  // fact about the running browser, and this function exists precisely to check the fact.
+  const table = browser as unknown as Record<string, Record<string, unknown> | undefined>;
+  try {
+    return typeof table[ns]?.[method] === "function";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Does this browser implement the `browser.<ns>.<event>` event?
+ *
+ * Separate from `apiPresent` because an event is an OBJECT carrying `addListener`, not a
+ * function, so a `typeof … === "function"` check answers "no" for every event that
+ * exists — which is a quiet way to switch off working listeners.
+ */
+export function eventPresent(ns: string, event: string): boolean {
+  const table = browser as unknown as
+    Record<string, Record<string, { addListener?: unknown } | undefined> | undefined>;
+  try {
+    return typeof table[ns]?.[event]?.addListener === "function";
+  } catch {
+    return false;
+  }
+}
+
+/** Does this browser implement the API a data type is built on? */
+export function dataTypeApiPresent(type: DataType): boolean {
+  const [ns, method] = API_FOR_TYPE[type];
+  return apiPresent(ns, method);
+}
+
+/**
+ * Whether a data type can be synced here, and if not, which kind of "not".
+ *
+ * The distinction matters because the two need opposite treatment. A permission we
+ * simply haven't asked for yet is one click away; an API the browser doesn't implement
+ * is never coming, and offering a toggle for it is a lie.
+ *
+ * Telling them apart takes a permission check, because an optional-permission API is
+ * `undefined` until its permission is granted — so a missing `browser.history` means
+ * "not granted yet" on Chrome and "never implemented" on Firefox for Android, and only
+ * `permissions.contains()` says which.
+ */
+export type Availability =
+  | { state: "ready" }
+  | { state: "needs-permission"; permission: string }
+  | { state: "unsupported" };
+
+export async function dataTypeAvailability(type: DataType): Promise<Availability> {
+  if (dataTypeApiPresent(type)) return { state: "ready" };
+
+  const permission = PERMISSION_FOR_TYPE[type];
+  // No optional permission gates it (bookmarks), so the permission is already held and
+  // the API is still not there. Nothing left to ask for.
+  if (!permission) return { state: "unsupported" };
+
+  // Permission held, API still absent → the browser doesn't implement it.
+  if (await hasPermission({ permissions: [permission] })) return { state: "unsupported" };
+
+  return { state: "needs-permission", permission };
+}
+
+/** Availability for every data type at once, for a UI that renders all four. */
+export async function allDataTypeAvailability(): Promise<Record<DataType, Availability>> {
+  const types = Object.keys(API_FOR_TYPE) as DataType[];
+  const entries = await Promise.all(types.map(async (t) => [t, await dataTypeAvailability(t)] as const));
+  return Object.fromEntries(entries) as Record<DataType, Availability>;
+}
+
+/**
+ * What to tell someone whose browser doesn't implement a data type's API.
+ *
+ * Named platforms rather than a bare "not supported": the first thing anyone does with
+ * "bookmarks can't sync" is check whether their setup is broken, and knowing it's the
+ * browser — and that the desktop build is fine — ends that search immediately.
+ */
+const UNSUPPORTED_MESSAGE: Record<DataType, string> = {
+  bookmarks: "This browser doesn't provide a bookmarks API, so bookmarks can't sync here. Firefox for Android is the usual case; bookmark sync works on desktop Firefox and on Chromium browsers.",
+  history: "This browser doesn't provide a history API, so history can't sync here. Firefox for Android is the usual case; history sync works on desktop Firefox and on Chromium browsers.",
+  sessions: "This browser doesn't provide a tabs API, so open tabs can't sync here.",
+  extensions: "This browser doesn't provide an extension-management API, so your extension list can't sync here.",
+};
+
+/** The sentence to show for a type this browser can't sync. */
+export function unsupportedReason(type: DataType): string {
+  return UNSUPPORTED_MESSAGE[type];
+}
+
+/**
+ * Throw a sentence a person can act on, rather than let the call fail as a TypeError.
+ *
+ * "Cannot read properties of undefined (reading 'getTree')" is what a Fennec user was
+ * shown for a browser that simply has no bookmarks API, and it reads like a crash in
+ * Konode. Every handler entry point checks this first.
+ */
+export function assertDataTypeApi(type: DataType): void {
+  if (!dataTypeApiPresent(type)) throw new Error(UNSUPPORTED_MESSAGE[type]);
+}
+
+// ─── Permissions ──────────────────────────────────────────────────────────
+
+/** `permissions.contains()`, never throwing — an unanswerable question is a "no". */
+export async function hasPermission(req: chrome.permissions.Permissions): Promise<boolean> {
+  try {
+    return await browser.permissions.contains(req);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * The result of trying to obtain a permission.
+ *
+ * `cannot-prompt` is the one that earns its place: Firefox for Android does not implement
+ * `permissions.request()` (bugzilla 1601420), so the call resolves false — or throws —
+ * no matter what the user would have said. Reporting that as "you declined" is simply
+ * false, and it is what left a Fennec user staring at "Konode needs permission to reach
+ * your WebDAV server" with no prompt in sight and no way forward. On that platform the
+ * permission has to be granted from Firefox's own add-on settings instead, which is
+ * something we can tell the user only if we know the difference.
+ */
+export type PermissionOutcome = "granted" | "denied" | "cannot-prompt";
+
+/**
+ * Make sure a permission is held, prompting only if it isn't.
+ *
+ * The `contains()` check FIRST is not an optimisation. On a browser whose prompt is
+ * broken it is the entire fix: a user who granted the permission by hand in the add-on's
+ * settings page holds it, and asking `request()` about it would still answer false and
+ * send them round the same loop again.
+ *
+ * MUST be called synchronously from a user gesture on browsers that do prompt — Firefox
+ * rejects a `request()` that has lost its gesture, and every `await` before it risks
+ * that. `contains()` runs first here, which is one await; that is safe because a request
+ * only happens when contains() answered false, and in that case the click is still the
+ * current task in every engine we've seen. Don't add more awaits before this call.
+ */
+export async function ensurePermission(req: chrome.permissions.Permissions): Promise<PermissionOutcome> {
+  if (await hasPermission(req)) return "granted";
+
+  let granted = false;
+  try {
+    granted = await browser.permissions.request(req);
+  } catch {
+    granted = false;
+  }
+  if (granted) return "granted";
+
+  // A false here is not proof of a refusal — see PermissionOutcome. Re-check what we
+  // actually hold before deciding which story to tell.
+  if (await hasPermission(req)) return "granted";
+
+  return (await promptsForPermissions()) ? "denied" : "cannot-prompt";
+}
+
+/**
+ * Can this browser show a runtime permission prompt at all?
+ *
+ * There is no capability bit for this — `permissions.request` is a perfectly normal
+ * function on Firefox for Android, it just never asks anybody. So this is the one place
+ * that has to identify the platform rather than the feature, and it does it through
+ * `runtime.getPlatformInfo()` rather than the user agent, which is spoofable.
+ *
+ * Cached: the answer cannot change within a page's lifetime, and the callers are click
+ * handlers.
+ */
+let promptsCache: boolean | undefined;
+export async function promptsForPermissions(): Promise<boolean> {
+  if (promptsCache !== undefined) return promptsCache;
+  promptsCache = !(await isAndroid());
+  return promptsCache;
+}
+
+/** Test seam: forget the cached platform answers. */
+export function resetCapabilityCache(): void {
+  promptsCache = undefined;
+  androidCache = undefined;
+}
+
+let androidCache: boolean | undefined;
+export async function isAndroid(): Promise<boolean> {
+  if (androidCache !== undefined) return androidCache;
+  try {
+    const info = await browser.runtime.getPlatformInfo();
+    androidCache = info.os === "android";
+  } catch {
+    // Older/limited builds may not answer. The user agent is a worse signal — it can be
+    // spoofed — but a wrong answer here only changes the wording of an error message,
+    // never whether something is allowed.
+    androidCache = /android/i.test(globalThis.navigator?.userAgent ?? "");
+  }
+  return androidCache;
+}

--- a/src/onboarding/App.tsx
+++ b/src/onboarding/App.tsx
@@ -7,7 +7,11 @@ import { interactiveSignIn, isDriveAuthAvailable } from "@/lib/backends/gdrive-o
 // Some engines (notably iOS WebKit, e.g. Orion) don't support interactive Google
 // sign-in; gate the Drive option so users aren't sent into a dead end.
 const DRIVE_AVAILABLE = isDriveAuthAvailable();
-import type { BackendType, SyncSettings } from "@/lib/types";
+import type { BackendType, DataType, SyncSettings } from "@/lib/types";
+import {
+  allDataTypeAvailability, ensurePermission, unsupportedReason,
+  PERMISSION_FOR_TYPE, type Availability,
+} from "@/lib/utils/capabilities";
 import {
   Bookmark,
   Clock, Puzzle, Globe, CheckCircle2, ArrowRight,
@@ -89,8 +93,37 @@ export default function OnboardingApp() {
     sessions: false,
   });
 
-  const toggleData = (key: keyof typeof dataTypes) =>
+  /**
+   * What this browser can actually sync — see lib/utils/capabilities.
+   *
+   * Empty until the check resolves, and `unsupported` is the only state the wizard acts
+   * on, so the brief unknown window can only ever leave a row enabled a moment longer
+   * than it should. Nothing is switched OFF on a guess.
+   */
+  const [availability, setAvailability] = useState<Partial<Record<DataType, Availability>>>({});
+  const unavailable = (key: DataType): boolean => availability[key]?.state === "unsupported";
+
+  useEffect(() => {
+    void (async () => {
+      const found = await allDataTypeAvailability();
+      setAvailability(found);
+      // Bookmarks ships on by default, so on a browser with no bookmarks API the wizard
+      // would otherwise finish with a data type that cannot produce a single byte — and
+      // the progress step would sit there waiting for a count that never moves.
+      setDataTypes((p) => {
+        const next = { ...p };
+        for (const key of Object.keys(next) as DataType[]) {
+          if (found[key]?.state === "unsupported") next[key] = false;
+        }
+        return next;
+      });
+    })();
+  }, []);
+
+  const toggleData = (key: keyof typeof dataTypes) => {
+    if (unavailable(key)) return;
     setDataTypes((p) => ({ ...p, [key]: !p[key] }));
+  };
 
   // Derived from the selected provider card.
   const backend: BackendType | null = provider ? providerById(provider).backend : null;
@@ -258,10 +291,16 @@ export default function OnboardingApp() {
     // who also enabled an optional data type (origin request, then perms request).
     // The chosen data types (history/tabs/management) and — for WebDAV — the server
     // origin (an arbitrary host not in host_permissions) go in the same request.
+    //
+    // Types this browser doesn't implement are left out: asking for `history` on a
+    // browser with no history API can only fail, and one unobtainable permission drags
+    // the whole combined request down with it — which is how a Fennec user ended up
+    // being told their WEBDAV permission was refused.
     const optPerms: string[] = [];
-    if (dataTypes.history) optPerms.push("history");
-    if (dataTypes.sessions) optPerms.push("tabs");
-    if (dataTypes.extensions) optPerms.push("management");
+    for (const type of ["history", "sessions", "extensions"] as const) {
+      const perm = PERMISSION_FOR_TYPE[type];
+      if (dataTypes[type] && perm && availability[type]?.state !== "unsupported") optPerms.push(perm);
+    }
 
     const origins: string[] = [];
     if (backend === "webdav") {
@@ -274,17 +313,20 @@ export default function OnboardingApp() {
     }
 
     if (optPerms.length || origins.length) {
-      let granted = false;
-      try {
-        granted = await browser.permissions.request({
-          ...(optPerms.length ? { permissions: optPerms } : {}),
-          ...(origins.length ? { origins } : {}),
-        });
-      } catch {
-        granted = false;
-      }
-      if (!granted) {
-        setSetupError(t(origins.length ? "onb_err_perms_webdav" : "onb_err_perms_types"));
+      const outcome = await ensurePermission({
+        ...(optPerms.length ? { permissions: optPerms } : {}),
+        ...(origins.length ? { origins } : {}),
+      });
+      if (outcome !== "granted") {
+        // Two different situations, and telling them apart is the whole point. On a
+        // browser that can't show the prompt at all (Firefox for Android), "please
+        // allow it" is advice for a dialog that will never appear — the permission has
+        // to be granted from the browser's own add-on settings instead.
+        setSetupError(
+          outcome === "cannot-prompt"
+            ? t("onb_err_perms_no_prompt")
+            : t(origins.length ? "onb_err_perms_webdav" : "onb_err_perms_types")
+        );
         return;
       }
     }
@@ -667,14 +709,19 @@ export default function OnboardingApp() {
               // a setting, and called sessions "tab groups", which is a Chrome feature
               // Konode does not sync.
               const desc = t(`datatype_${key}_desc`);
+              // A type this browser has no API for. Shown rather than hidden, with the
+              // reason: a row that quietly disappears reads as a missing feature, and the
+              // one thing this user needs to know is that it's the browser, not Konode.
+              const off = unavailable(key);
               return (
               <label
                 key={key}
-                style={S.dataRow}
+                style={{ ...S.dataRow, ...(off ? { opacity: 0.55, cursor: "not-allowed" } : null) }}
                 role="switch"
                 aria-checked={dataTypes[key]}
+                aria-disabled={off}
                 aria-label={label}
-                tabIndex={0}
+                tabIndex={off ? -1 : 0}
                 onClick={() => toggleData(key)}
                 onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); toggleData(key); } }}
               >
@@ -682,18 +729,22 @@ export default function OnboardingApp() {
                   <Icon size={16} color={dataTypes[key] ? "var(--accent)" : "var(--text-secondary)"} />
                   <div>
                     <div style={{ fontSize: 14, color: "var(--text-primary)" }}>{label}</div>
-                    <div style={{ fontSize: 12, color: "var(--text-secondary)" }}>{desc}</div>
+                    <div style={{ fontSize: 12, color: "var(--text-secondary)" }}>
+                      {off ? unsupportedReason(key) : desc}
+                    </div>
                   </div>
                 </div>
-                <div style={{
-                  ...S.toggleTrack,
-                  background: dataTypes[key] ? "var(--accent)" : "var(--toggle-off)",
-                }}>
+                {!off && (
                   <div style={{
-                    ...S.toggleThumb,
-                    transform: dataTypes[key] ? "translateX(16px)" : "translateX(0)",
-                  }} />
-                </div>
+                    ...S.toggleTrack,
+                    background: dataTypes[key] ? "var(--accent)" : "var(--toggle-off)",
+                  }}>
+                    <div style={{
+                      ...S.toggleThumb,
+                      transform: dataTypes[key] ? "translateX(16px)" : "translateX(0)",
+                    }} />
+                  </div>
+                )}
               </label>
               );
             })}

--- a/src/options/App.tsx
+++ b/src/options/App.tsx
@@ -1517,6 +1517,19 @@ export default function OptionsApp() {
                           <div className="row-desc">
                             {off ? unsupportedReason(type) : t(`datatype_${type}_desc`)}
                           </div>
+                          {/* Switched on, browser can do it, permission gone. Browsers let
+                              you revoke an optional permission from their own extension
+                              settings and tell the extension nothing, so this type would
+                              otherwise sit here looking enabled and sync nothing at all. */}
+                          {settings.enabled_types.includes(type)
+                            && availability[type]?.state === "needs-permission"
+                            && typeError?.type !== type && (
+                            <div className="error-row" role="alert">
+                              <AlertTriangle size={12} /> Konode doesn't have the permission
+                              this needs any more, so it isn't syncing. Switch it off and on
+                              again to restore it.
+                            </div>
+                          )}
                           {typeError?.type === type && (
                             <div className="error-row" role="alert">
                               <AlertTriangle size={12} /> {typeError.message}

--- a/src/options/App.tsx
+++ b/src/options/App.tsx
@@ -3,6 +3,11 @@ import type { SyncSettings, SyncState, BackendType, DataType, BackendConfig, Syn
 import { sendMessage, request } from "@/lib/utils/messaging";
 import { t, tParts } from "@/lib/utils/i18n";
 import { interactiveSignIn, isDriveAuthAvailable } from "@/lib/backends/gdrive-oauth";
+import {
+  allDataTypeAvailability, dataTypeAvailability, dataTypeApiPresent, ensurePermission,
+  hasPermission, unsupportedReason,
+  PERMISSION_FOR_TYPE, type Availability, type PermissionOutcome,
+} from "@/lib/utils/capabilities";
 
 /**
  * Which edges of a scroller still have content past them.
@@ -265,6 +270,13 @@ export default function OptionsApp() {
   // three of the four tabs Save just did nothing, with no explanation anywhere.
   const [saveError, setSaveError] = useState<string | null>(null);
   const [testing, setTesting]     = useState(false);
+
+  // What this browser can actually sync, and why a toggle refused to move. Both live
+  // next to the row they belong to — see toggleDataType and the Data Types tab.
+  const [availability, setAvailability] = useState<Partial<Record<DataType, Availability>>>({});
+  const [typeError, setTypeError] = useState<{ type: DataType; message: string } | null>(null);
+
+  useEffect(() => { void allDataTypeAvailability().then(setAvailability); }, []);
 
   // Google Drive
   const [gdriveUser, setGdriveUser]           = useState<{ email: string; displayName: string } | null>(null);
@@ -621,16 +633,28 @@ export default function OptionsApp() {
   // WebDAV hits an arbitrary user host that isn't in host_permissions, so we
   // request it at runtime (optional_host_permissions). Must run inside a user
   // gesture, so call it first — before any await — in the click handlers below.
-  const requestWebdavHostPermission = async (): Promise<boolean> => {
+  const requestWebdavHostPermission = async (): Promise<PermissionOutcome | "bad-url"> => {
     const url = getBackend("webdav")?.webdav?.url;
-    if (!url) return false;
+    if (!url) return "bad-url";
     try {
       const origin = new URL(url).origin + "/*";
-      return await browser.permissions.request({ origins: [origin] });
+      return await ensurePermission({ origins: [origin] });
     } catch {
-      return false;
+      return "bad-url";
     }
   };
+
+  /** What to say when the WebDAV host permission didn't come through.
+   *
+   *  "Permission was not granted" was the only answer this had, and on Firefox for
+   *  Android it was actively misleading: there is no prompt to decline there, so the
+   *  user is told they refused something they were never asked. */
+  const webdavPermissionError = (outcome: PermissionOutcome | "bad-url"): string =>
+    outcome === "cannot-prompt"
+      ? "This browser can't show permission prompts, so Konode couldn't ask for access to your WebDAV server. Grant it on Konode's permissions screen in your browser's extension settings, then try again."
+      : outcome === "bad-url"
+        ? "Konode has no usable WebDAV address to ask for access to. Check the server URL above."
+        : "Permission to access the WebDAV server was not granted.";
 
   const save = async () => {
     if (!settings) return;
@@ -644,9 +668,9 @@ export default function OptionsApp() {
       return;
     }
     if (settings.active_backend === "webdav") {
-      const granted = await requestWebdavHostPermission();
-      if (!granted) {
-        setSaveError("Permission to access the WebDAV server was not granted.");
+      const outcome = await requestWebdavHostPermission();
+      if (outcome !== "granted") {
+        setSaveError(webdavPermissionError(outcome));
         return;
       }
     }
@@ -716,9 +740,9 @@ export default function OptionsApp() {
   const testBackend = async () => {
     if (!settings?.active_backend) return;
     if (settings.active_backend === "webdav") {
-      const granted = await requestWebdavHostPermission();
-      if (!granted) {
-        setTestStatus({ ok: false, message: "Permission to access the WebDAV server was not granted." });
+      const outcome = await requestWebdavHostPermission();
+      if (outcome !== "granted") {
+        setTestStatus({ ok: false, message: webdavPermissionError(outcome) });
         return;
       }
     }
@@ -730,20 +754,38 @@ export default function OptionsApp() {
 
   // history/tabs/management are optional permissions now — request them on enable
   // so the install-time prompt stays minimal (and the CWS review stays clean).
-  const PERM_FOR_TYPE: Partial<Record<DataType, string>> = {
-    history: "history",
-    sessions: "tabs",
-    extensions: "management",
-  };
-
+  //
+  // Turning one ON used to be all-or-nothing and completely silent about it: if the
+  // permission request came back false the function simply returned, the switch sprang
+  // back, and nothing anywhere said why. On Firefox for Android — where the request can
+  // never succeed — that is a toggle that just refuses to move, which is exactly what a
+  // user reported about History. Now the reason is on screen either way.
   const toggleDataType = async (type: DataType) => {
     if (!settings) return;
     const enabling = !settings.enabled_types.includes(type);
     if (enabling) {
-      const perm = PERM_FOR_TYPE[type];
+      setTypeError(null);
+      const perm = PERMISSION_FOR_TYPE[type];
       if (perm) {
-        const granted = await browser.permissions.request({ permissions: [perm] });
-        if (!granted) return; // leave it off if the user declined the permission
+        const outcome = await ensurePermission({ permissions: [perm] });
+        if (outcome !== "granted") {
+          setTypeError({
+            type,
+            message: outcome === "cannot-prompt"
+              ? `This browser can't show permission prompts, so Konode couldn't ask for the "${perm}" permission. Grant it on Konode's permissions screen in your browser's extension settings, then try again.`
+              : `Konode needs the "${perm}" permission to sync this. It stays off until that's allowed.`,
+          });
+          return;
+        }
+      }
+      // Permission in hand and STILL no API — the browser doesn't implement it. Re-check
+      // rather than trust the value we loaded on mount: granting the permission is what
+      // makes an optional-permission API appear, so this is the first honest answer.
+      const state = await dataTypeAvailability(type);
+      setAvailability((prev) => ({ ...prev, [type]: state }));
+      if (state.state === "unsupported") {
+        setTypeError({ type, message: unsupportedReason(type) });
+        return;
       }
     }
     const next = enabling
@@ -783,12 +825,18 @@ export default function OptionsApp() {
       // Collect all syncable data. history/management are optional permissions —
       // only query them when granted, so a user who never enabled those types still
       // gets a working bookmarks export instead of the whole thing throwing.
+      // Permission AND API, because they can disagree: a browser can hold the permission
+      // and never have implemented what sits behind it. Checking only the permission is
+      // how one missing API turned the whole export — bookmarks included — into a
+      // silent failure.
       const [hasHistory, hasMgmt] = await Promise.all([
-        browser.permissions.contains({ permissions: ["history"] }),
-        browser.permissions.contains({ permissions: ["management"] }),
+        dataTypeApiPresent("history") ? hasPermission({ permissions: ["history"] }) : Promise.resolve(false),
+        dataTypeApiPresent("extensions") ? hasPermission({ permissions: ["management"] }) : Promise.resolve(false),
       ]);
       const [bookmarkTree, extensions, historyItems] = await Promise.all([
-        browser.bookmarks.getTree(),
+        dataTypeApiPresent("bookmarks")
+          ? browser.bookmarks.getTree()
+          : Promise.resolve([] as chrome.bookmarks.BookmarkTreeNode[]),
         hasMgmt
           ? browser.management.getAll()
           : Promise.resolve([] as chrome.management.ExtensionInfo[]),
@@ -1440,24 +1488,43 @@ export default function OptionsApp() {
 
               <div className="settings-section">
                 <div className="settings-card-head">Data to sync</div>
-                {DATA_TYPES.map((type) => (
-                  <div key={type} className="settings-row">
-                    <div className="settings-row-left">
-                      <div>
-                        <div className="row-label">{t(`datatype_${type}`)}</div>
-                        <div className="row-desc">{t(`datatype_${type}_desc`)}</div>
+                {DATA_TYPES.map((type) => {
+                  // Not implemented by this browser: keep the row, drop the switch, and
+                  // put the reason where the description was. A dead toggle that springs
+                  // back is the one outcome this must never produce again.
+                  const off = availability[type]?.state === "unsupported";
+                  return (
+                    <div key={type} className={`settings-row${off ? " is-unavailable" : ""}`}>
+                      <div className="settings-row-left">
+                        <div>
+                          <div className="row-label">{t(`datatype_${type}`)}</div>
+                          <div className="row-desc">
+                            {off ? unsupportedReason(type) : t(`datatype_${type}_desc`)}
+                          </div>
+                          {typeError?.type === type && (
+                            <div className="error-row" role="alert">
+                              <AlertTriangle size={12} /> {typeError.message}
+                            </div>
+                          )}
+                        </div>
                       </div>
+                      {!off && (
+                        <label className="toggle-wrap">
+                          <input type="checkbox" className="toggle-input"
+                            checked={settings.enabled_types.includes(type)}
+                            onChange={() => toggleDataType(type)} />
+                          <span className="toggle-track"><span className="toggle-thumb" /></span>
+                        </label>
+                      )}
                     </div>
-                    <label className="toggle-wrap">
-                      <input type="checkbox" className="toggle-input"
-                        checked={settings.enabled_types.includes(type)}
-                        onChange={() => toggleDataType(type)} />
-                      <span className="toggle-track"><span className="toggle-thumb" /></span>
-                    </label>
-                  </div>
-                ))}
+                  );
+                })}
               </div>
 
+              {/* Nothing to configure when the browser has no history API — the row above
+                  already explains why, and a live "days to sync" slider under it would
+                  only suggest the feature is one setting away. */}
+              {availability.history?.state !== "unsupported" && (
               <div className="settings-section">
                 <div className="settings-card-head">History</div>
                 <div className="settings-row">
@@ -1486,6 +1553,7 @@ export default function OptionsApp() {
                   today rather than the day you were browsing. Firefox keeps the original date.
                 </InfoHint>
               </div>
+              )}
 
               {missingExtensions.length > 0 && (
                 <>
@@ -2130,6 +2198,10 @@ const STYLES = `
   .settings-row:hover:not(.row-disabled) { background: var(--bg-hover); }
   .settings-row.radio-row { cursor: pointer; }
   .settings-row.row-disabled { opacity: .45; pointer-events: none; }
+  /* Not "disabled": there is nothing left to disable, the switch itself is gone. Only the
+     LABEL dims — the sentence explaining why is the entire content of the row and has to
+     stay properly readable, which is exactly what a blanket opacity would ruin. */
+  .settings-row.is-unavailable .row-label { color: var(--text-secondary); }
   .settings-row-left { display: flex; align-items: flex-start; gap: var(--sp-md); flex: 1; min-width: 0; }
   .row-icon { color: var(--text-secondary); margin-top: 1px; flex-shrink: 0; }
   .row-label { font-size: var(--fs-sm); color: var(--text-primary); }

--- a/src/options/App.tsx
+++ b/src/options/App.tsx
@@ -392,10 +392,21 @@ export default function OptionsApp() {
       // options "missing on this device" list stayed empty (the popup was correct).
       setRemoteExtensions(normalizeRemoteExtensions(r[KEYS.REMOTE_EXTENSIONS]));
     });
-    // "management" is optional — this may reject if not granted; ignore then.
-    void browser.management.getAll()
-      .then((exts) => setLocalExts(exts.map((e) => ({ id: e.id, name: e.name, homepageUrl: e.homepageUrl }))))
-      .catch(() => {});
+    // "management" is optional, and the `.catch()` below was built on a wrong idea of what
+    // happens without it. Chrome does not hide the namespace: `chrome.management` is always
+    // there, carrying only `getSelf`/`uninstallSelf` until the permission is granted. So
+    // `getAll` is not a function, and the call throws SYNCHRONOUSLY, before any promise
+    // exists for `.catch()` to catch. Thrown from inside an effect, that unmounts the tree,
+    // and the whole Settings page renders blank.
+    //
+    // That is the default state of a fresh install: 1.2.0 made `management` optional, and
+    // the wizard only asks for it if you switch extension sync on. Reported twice (#5, and
+    // again with the exact "g.management.getAll is not a function" stack).
+    if (dataTypeApiPresent("extensions")) {
+      void browser.management.getAll()
+        .then((exts) => setLocalExts(exts.map((e) => ({ id: e.id, name: e.name, homepageUrl: e.homepageUrl }))))
+        .catch(() => {});
+    }
   }, [load]);
 
   // Load Statistics data once on mount: sync state (last sync, counts, bytes), a live
@@ -888,8 +899,10 @@ export default function OptionsApp() {
 
       let imported = 0;
 
-      // Import bookmarks
-      if (data.bookmarks) {
+      // Import bookmarks. The API check is not paranoia: a backup file can be opened on a
+      // browser that has no bookmarks API, and without this the import dies on a TypeError
+      // and reports a generic failure for a file that is perfectly fine.
+      if (data.bookmarks && dataTypeApiPresent("bookmarks")) {
         const roots = (await browser.bookmarks.getTree())[0]?.children ?? [];
         const otherId = defaultOtherRootId(roots); // browser-agnostic "Other bookmarks"
 
@@ -921,8 +934,11 @@ export default function OptionsApp() {
         }
       }
 
-      // Import history
-      if (Array.isArray(data.history)) {
+      // Import history. Same reasoning as the bookmarks guard above, plus one of its own:
+      // `history` is an optional permission, so on a browser that gates the namespace this
+      // is undefined until it is granted, and every single item would throw into its own
+      // catch and be silently dropped.
+      if (Array.isArray(data.history) && dataTypeApiPresent("history")) {
         for (const item of data.history) {
           if (item.url && isSafeContentUrl(item.url)) try { await browser.history.addUrl({ url: item.url }); } catch { /* skip */ }
         }

--- a/src/popup/App.tsx
+++ b/src/popup/App.tsx
@@ -8,6 +8,7 @@ import { KEYS, getSettings, getState, normalizeRemoteSessions, normalizeRemoteEx
 import { STATE_UPDATE } from "@/lib/constants";
 import { streamState, streamInputFor, streamColor, streamLabelKey } from "@/popup/stream-state";
 import { t, plural } from "@/lib/utils/i18n";
+import { dataTypeApiPresent, hasPermission } from "@/lib/utils/capabilities";
 import {
   RefreshCw, Settings, Bookmark, Clock, Globe,
   AlertCircle, Loader2, ChevronRight,
@@ -116,8 +117,12 @@ export default function PopupApp() {
       // Union of every peer device's extension list (deduped by id).
       const remote = normalizeRemoteExtensions(r[KEYS.REMOTE_EXTENSIONS]);
       if (!remote.length) return;
-      // "management" is an optional permission now — only query if it was granted.
-      const hasMgmt = await browser.permissions.contains({ permissions: ["management"] });
+      // "management" is an optional permission now — only query if it was granted, and
+      // only if this browser has the API behind it at all. Those are two different
+      // questions: a permission can be held on a browser that never implemented the API,
+      // and then the call below is a TypeError inside a popup, where nobody sees it.
+      if (!dataTypeApiPresent("extensions")) return;
+      const hasMgmt = await hasPermission({ permissions: ["management"] });
       if (!hasMgmt) return;
       const local = await browser.management.getAll();
       const here = currentStore();

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -210,7 +210,27 @@ function makeBookmarks() {
 
 function makeChrome() {
   return {
-    runtime: { id: "test-extension-id", lastError: undefined },
+    runtime: {
+      id: "test-extension-id",
+      lastError: undefined,
+      // Desktop by default. lib/utils/capabilities asks this to work out whether the
+      // browser can show a permission prompt at all (Firefox for Android can't), so the
+      // fake has to answer — a test that wants the mobile answer overrides it.
+      getPlatformInfo: () => Promise.resolve({ os: "win", arch: "x86-64" }),
+    },
+    // A browser where every permission is already held. That is what the manifest's
+    // required permissions look like at runtime, and the optional ones are granted by
+    // the same code path in every test that exercises a type needing one.
+    permissions: {
+      contains: () => Promise.resolve(true),
+      request: () => Promise.resolve(true),
+      getAll: () => Promise.resolve({ permissions: [], origins: [] }),
+      remove: () => Promise.resolve(true),
+    },
+    // Present but empty. It exists at all because the capability checks read the API
+    // surface to decide what this browser can sync, and a fake missing `management`
+    // models a browser that cannot sync extensions — which is not what these tests mean.
+    management: { getAll: () => Promise.resolve([]) },
     storage: {
       local: {
         get: (keys) => {


### PR DESCRIPTION
Patch release. Four field reports over two days, and they turned out to be one assumption: Konode treated a permission its manifest declares as proof the browser implements the feature behind it. That is not true on Firefox for Android, not true on Chrome for an optional permission that has not been granted, and not reliably true on WebKit engines either.

`src/lib/utils/capabilities.ts` is the one place that now answers "can this browser actually do X", by reading the API surface rather than sniffing the engine, so it answers correctly for browsers that do not exist yet.

## The reports

**Blank Settings page. Fixes #5.** Reproduced on a fresh 1.2.0 install on Helium: complete the wizard with the extension list deliberately left off, open Settings, get a black page and `management.getAll is not a function` at `options.js:56`.

1.2.0 moved `management` to `optional_permissions` and the mount effect asked for the extension list anyway. The `.catch(() => {})` on that call was written for the wrong failure: Chrome does not hide the namespace when the permission is missing, it hands back a `management` object carrying only `getSelf`/`uninstallSelf`. So `getAll` is not a function, the call throws synchronously before any promise exists to reject, and thrown from inside an effect React unmounts the tree. Anyone who did not switch extension sync on hit this, which is the default.

**Orion: history and extensions did not sync.** Both failed every cycle with a raw `undefined is not an object (evaluating 'u.history.search')`, and nothing said why. Bookmarks and sessions were fine, so the sync looked healthy apart from log noise. Two different situations were being conflated, and they need opposite handling:

- the browser does not implement it: a standing fact, cannot be fixed, so skip quietly and say so in Settings
- the optional permission is not granted: the user's to fix, so report it with the steps

Browsers let you revoke an optional permission from their own settings without telling the extension, so the second is reachable at any time on a working install. `syncAllTypes` now asks `dataTypeAvailability()` instead of just "is the API there", and carries on syncing everything else either way.

**Firefox for Android** (Reddit, a very thorough report). Four symptoms, one cause:

- `permissions.request()` is unimplemented on GeckoView, so every runtime request came back refused with no prompt ever shown. Setup reported that as "Konode needs permission to reach your WebDAV server", about a server that had nothing to do with it. Permissions are now checked with `contains()` before asking, so one granted by hand in the browser's add-on settings is simply accepted, and a browser that cannot ask is told apart from a user who said no.
- The History toggle sprang back with no explanation, for the same reason.
- No bookmarks API and no history API on that platform, so `exportBookmarks` failed with `Cannot read properties of undefined (reading 'getTree')`, which reads as a crash in Konode rather than a limit of the browser. Both types now report themselves unavailable, with the reason, and the sync skips them.
- `registerBookmarkListeners` runs at the background script's top level, so the same missing API threw during module evaluation and took the rest of the file with it.

**That last shape, everywhere else it occurs.** The Orion report sent me back through the rest of the code with the same question. `service-worker.ts` registers every listener at module scope, because MV3 requires them attached on each worker load, which made the file one long fuse: the first missing event throws and nothing below it runs, including `ensureInit()` at the bottom. Each registration now goes through a small `on()` helper. `notifyConflict()` is called from inside a sync, so a browser with no notifications API would have failed the sync over a toast.

`runtime.onMessage` is deliberately left bare. It is the one API without which nothing works at all, so there is no degraded mode to survive into.

## Changelog backfill

The `v1.2.0` tag is 25 commits behind `main`, and nothing after it had a changelog entry. The black page bounds which of those actually reached users: with the error boundary (c5b997f) present that crash would have rendered the fallback card instead of nothing, so the shipped build predates it, and everything from there onward never shipped. Those now have entries: the error boundary, two "missing on this device" fixes, the store listing name, the wizard's squashed provider logos.

**Still open, and it decides the version number.** The i18n commits sit *before* c5b997f, so whether Hungarian and German already reached users is unknown from here. If they did not, this is a feature release and should be 1.3.0 rather than 1.2.1, with a changelog entry to match.

## Notes

- `npm run check` green, 451 tests. `web-ext lint` reports 0 errors (the 2 warnings are pre-existing, from a vendored chunk).
- The test fake gained `permissions`, `management` and `getPlatformInfo`. A fake missing those was modelling a crippled browser, which is not what the suite means.
- No change to the sync file format, and no new permissions.
- `TROUBLESHOOTING.md` gains a Firefox for Android section.
- Container sync for tabs came up alongside this and is filed separately as #6. Not in scope here.

## After merge

Tag the release to cut it on GitHub. Remember that the zips the release workflow attaches are source builds without `VITE_GOOGLE_CLIENT_SECRET`; the Chrome Web Store and AMO uploads are built locally with it, as the workflow comment spells out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TctSQHzQcyAPHCNdxGADzV