### PR TITLE
Unblock the l10n CI, and two claims that had drifted from the truth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,17 @@ it can't.
   and took the rest of the script down with it, leaving an extension that had started but
   wasn't finished, which looks like it's working.
 
+### Where you can get it
+
+1.2.1 is live on **[Firefox Add-ons](https://addons.mozilla.org/firefox/addon/konode/)**,
+so Firefox and Waterfox update to it on their own. On the Chrome Web Store it is in review,
+and the listing serves 1.2.0 until that clears; Chrome updates itself once it does. If you
+would rather not wait, the Chrome zip is on the
+[v1.2.1 release](https://github.com/konabe-studio/konode/releases/tag/v1.2.1) page. Note
+that the release zips are built without Konode's own Google OAuth client, so Google Drive
+sign-in in those needs an OAuth client of your own. GitHub and WebDAV work with no extra
+setup.
+
 ## [1.2.0] - 2026-08-04
 
 A full code-review pass over the sync engine, the storage backends and the interface,

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -39,7 +39,7 @@ on any Chromium browser and on Firefox.
   with the manifest `key` stripped (the CWS rejects `key` on a first upload) while
   `dist/` keeps it for unpacked dev; pushing a `v*` tag runs a GitHub Actions release
   that attaches both packaged zips, Chrome and Firefox (source builds, no client secret).
-  Released through v1.2.0.
+  Released through v1.2.1.
 - **Pre-submission hardening**: a peer's extension `storeUrl` is rebuilt locally
   from the id (a forged URL was a phishing vector); onboarding requests all optional
   permissions in one call (a second request lost the user gesture); the dead
@@ -59,10 +59,16 @@ on any Chromium browser and on Firefox.
   propagating. See `CHANGELOG.md`.
 
 ## Now live
-Konode **1.2.0 is live on both stores**: the Chrome Web Store (first published 2026-07-20,
-item ID `mmlfiiimnpnjcjhhbldenpcmnibedkfa`) and
-[Firefox Add-ons](https://addons.mozilla.org/firefox/addon/konode/) (2026-08-04). Nothing
-is waiting on a submission.
+Konode is live on both stores, and the two are one patch apart:
+**Firefox Add-ons serves 1.2.1**, the Chrome Web Store still serves **1.2.0**.
+
+- [Firefox Add-ons](https://addons.mozilla.org/firefox/addon/konode/): **1.2.1**, listed
+  since 2026-08-04.
+- Chrome Web Store: **1.2.0**, first published 2026-07-20, item ID
+  `mmlfiiimnpnjcjhhbldenpcmnibedkfa`.
+
+The gap is the only thing outstanding on the store side, and it is already moving: 1.2.1
+is uploaded to the Chrome Web Store and **waiting on review**. Nothing is waiting on us.
 
 ## Next
 - **Backend expansion**, cheapest sign-in first. See *Platform priority* item 3 below.
@@ -201,12 +207,14 @@ pitch.
 
 **Chrome Web Store.** 1.0.0 submitted for review on **2026-07-19**, **published
 2026-07-20** (<https://chromewebstore.google.com/detail/konode/mmlfiiimnpnjcjhhbldenpcmnibedkfa>).
-1.2.0 is what the listing serves today.
+**1.2.0 is what the listing serves today**, so it is one patch behind Firefox: 1.2.1 is
+uploaded and in review.
 
 **Firefox Add-ons.** Live at <https://addons.mozilla.org/firefox/addon/konode/> since
-**2026-08-04**, shipped with 1.2.0. Packaged with `npm run package:firefox` and checked
-with `npm run lint:firefox`. AMO requires a source submission, since the build is bundled
-and minified, and the reviewer rebuilds and diffs it.
+**2026-08-04**, first listed with 1.2.0 and **serving 1.2.1 today**. Packaged with
+`npm run package:firefox` and checked with `npm run lint:firefox`. AMO requires a source
+submission, since the build is bundled and minified, and the reviewer rebuilds and diffs
+it.
 
 Done for the Chrome Web Store: keyless store package (`npm run package:chrome`), $5
 developer registration,

--- a/src/lib/utils/i18n.test.ts
+++ b/src/lib/utils/i18n.test.ts
@@ -162,13 +162,34 @@ describe.each(languages.filter((l) => l !== "en"))("the %s catalogue", (lang) =>
 
   it("keeps every placeholder, so no interpolated value goes missing", () => {
     // The classic translation loss: the sentence survives, `$COUNT$` doesn't, and the
-    // count silently disappears from the screen.
+    // count silently disappears from the screen. The mirror case is just as bad and reads
+    // worse: a `$NAME$` English never had is declared nowhere, so nothing substitutes it
+    // and the raw `$NAME$` ships to the screen. Both are what this hunts.
+    //
+    // Two things deliberately DON'T count as broken, because neither loses a value and
+    // failing over them cost us more than it ever caught:
+    //
+    // A key this language hasn't translated yet. chrome.i18n falls back per message, so an
+    // absent key renders the whole English string, `$COUNT$` included — nothing is lost.
+    // Counting those failed the build over every unfinished language, which is the state
+    // the SHIPPED note above calls normal and healthy, and buried any real break under a
+    // wall of them: of 22 reported on the first Weblate contribution, 21 were this.
+    //
+    // The same placeholder used more than once. getMessage substitutes EVERY occurrence,
+    // so repeating one is a normal thing to need — zh_Hans names the region twice because
+    // that is how the sentence works in Chinese — and it interpolates correctly both
+    // times. What matters is WHICH placeholders appear, not how often, so compare sets.
+    const names = (s: string) => new Set([...s.matchAll(/\$([A-Z_]+)\$/g)].map((m) => m[1]));
     const broken: string[] = [];
     for (const [key, entry] of Object.entries(en)) {
-      const want = [...entry.message.matchAll(/\$([A-Z_]+)\$/g)].map((m) => m[1]).sort();
-      if (!want.length) continue;
-      const got = [...(other[key]?.message ?? "").matchAll(/\$([A-Z_]+)\$/g)].map((m) => m[1]).sort();
-      if (want.join() !== got.join()) broken.push(`${key}: expected ${want.join()}, found ${got.join() || "none"}`);
+      const translated = other[key]?.message;
+      if (translated === undefined) continue;
+      const want = names(entry.message);
+      const got = names(translated);
+      const lost = [...want].filter((n) => !got.has(n));
+      const invented = [...got].filter((n) => !want.has(n));
+      if (lost.length) broken.push(`${key}: dropped $${lost.join("$, $")}$`);
+      if (invented.length) broken.push(`${key}: invented $${invented.join("$, $")}$`);
     }
     expect(broken).toEqual([]);
   });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,5 +14,13 @@ export default defineConfig({
     environment: "node", // Node 20 provides crypto.subtle / btoa / TextEncoder
     setupFiles: ["./test/setup.ts"],
     include: ["src/**/*.test.ts"],
+    // The E2EE tests derive real keys at the shipped 600k PBKDF2 iterations, which is a
+    // security parameter, not a knob to turn down for the suite: lowering it in tests would
+    // leave the value we actually ship untested. Several of them derive more than once (a
+    // round trip, then a wrong passphrase, then a verifier), so the default 5s is not enough
+    // on a slower machine, and CI's faster runners hid it. What that cost was the worst kind
+    // of red: four timed-out crypto tests that look like a broken encryption change and are
+    // nothing of the sort. Generous on purpose, and it never fires when things are working.
+    testTimeout: 30_000,
   },
 });


### PR DESCRIPTION
Three separate things, one per commit. The first is the one with someone waiting on it.

## The l10n CI, and what was actually wrong

**Unblocks #4**, our first Weblate contribution, red since 2026-08-04 with 22 placeholder breaks across et, it and zh_Hans. Every one of the 22 was this test's fault.

**21 of them: an absent key is not a dropped placeholder.** `chrome.i18n` falls back per message, so an untranslated key renders the whole English string, `$COUNT$` included. Nothing is lost. Counting those as breaks failed the build over every unfinished language, which is precisely the state the `SHIPPED` note three lines above the test calls normal and healthy. et is 22/123 translated and reported 14; it is 55/123 and reported 7.

**The 22nd: repeating a placeholder is not a break either.** zh_Hans `provider_pcloud_note` was reported as `expected REGION, found REGION,REGION`. `getMessage` substitutes every occurrence, so it interpolates correctly both times, and the Chinese sentence needs the region named twice to work:

> 如果你的 pCloud 账户位于 $REGION$ 区域，请选择 $REGION$ 区域。

The test compared sorted lists with `join()`, which bound the *number* of occurrences on top of the identity of them. It compares sets now, and names the two things that genuinely go wrong separately: `dropped $NAME$` (the value disappears off the screen) and `invented $NAME$` (declared nowhere, so the literal `$NAME$` ships to the screen).

Verified against #4's five catalogues in a worktree: **all pass, no translation edits needed**. Then verified the net still works, by dropping `$COUNT$` from one hu string and inventing `$BOGUS$` in another:

```
"popup_tabs_other: dropped $COUNT$",
"provider_syncing_to: invented $BOGUS$",
```

## The E2EE test timeout

`npm run check` was red on a slower machine and green in CI, which is the worst way for this to present: four timed-out crypto tests read as a broken encryption change and are nothing of the sort. All 92 pass at 30s.

The cause is deliberate. Those tests derive real keys at the shipped 600k PBKDF2 iterations, several of them more than once, so one test can spend well past 5s inside `crypto.subtle` alone. Not lowering the iteration count for tests, because 600k is a security parameter and a test-only value would leave the number we actually ship untested.

## The store versions

ROADMAP claimed "1.2.0 is live on both stores" and "nothing is waiting on a submission". Checked both listings instead of trusting the file: **Firefox Add-ons answers 1.2.1, the Chrome Web Store answers 1.2.0.** The two have diverged, so a straight 1.2.0 → 1.2.1 substitution would have swapped one wrong claim for another.

Both statuses are now stated separately, the Web Store upload is recorded as in review, and the changelog gets a "Where you can get it" for 1.2.1 in the shape 1.2.0 already used. Remaining 1.2.0 mentions are historical and stay. README needed nothing: its AMO badge comes from shields.io, so it already reads 1.2.1.

## Checks

`npm run check` green: 451 tests, 32 files, type-check and lint clean.

## After merge

Re-run #4's checks so the green is on the record, then it is mergeable. Worth merging the catalogues without adding the new languages to `SHIPPED`: an unshipped language just sits in the folder and falls back to English, whereas shipping one needs somebody who reads it. hu is 123/123, es 121/123 and zh_Hans 122/123 are close, et and it are early.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
