### PR TITLE
i18n: the Settings page was never translatable, and it is half the copy in the extension

### DIFF
--- a/public/_locales/de/messages.json
+++ b/public/_locales/de/messages.json
@@ -616,5 +616,576 @@
   },
   "opt_setup_sub": {
     "message": "Konode synchronisiert deinen Browser mit einem Speicher, der dir gehört. Es gibt keinen Konode-Server. Zwei kurze Schritte und du bist fertig. (Falls der Einrichtungsassistent in deinem Browser nie geöffnet wurde, kannst du alles direkt hier erledigen.)"
+  },
+  "opt_data_head": {
+    "message": "Datentypen"
+  },
+  "opt_data_head_sub": {
+    "message": "Wähle aus, was zwischen deinen Geräten synchronisiert wird."
+  },
+  "opt_data_section": {
+    "message": "Zu synchronisierende Daten"
+  },
+  "opt_data_permission_lost": {
+    "message": "Konode hat die dafür nötige Berechtigung nicht mehr, deshalb wird nicht synchronisiert. Schalte es aus und wieder ein, um sie neu zu erteilen."
+  },
+  "opt_history_days_label": {
+    "message": "Zu synchronisierende Tage"
+  },
+  "opt_history_days_desc": {
+    "message": "Empfohlen: 30 Tage."
+  },
+  "opt_history_days_value": {
+    "message": "$COUNT$ T",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "30"
+      }
+    }
+  },
+  "opt_history_hint": {
+    "message": "Seiten von deinen anderen Geräten werden mit dem Zeitpunkt ihrer Ankunft eingetragen, nicht mit dem Zeitpunkt deines ersten Besuchs. In Chromium-Browsern erscheinen sie deshalb unter heute und nicht an dem Tag, an dem du gesurft hast. Firefox behält das ursprüngliche Datum."
+  },
+  "opt_missing_ext_head": {
+    "message": "Fehlende Erweiterungen ($COUNT$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "6"
+      }
+    }
+  },
+  "opt_ext_from": {
+    "message": "· von $STORE$",
+    "placeholders": {
+      "store": {
+        "content": "$1",
+        "example": "Firefox"
+      }
+    }
+  },
+  "opt_ext_install": {
+    "message": "Installieren"
+  },
+  "opt_ext_find": {
+    "message": "Suchen"
+  },
+  "opt_no_password_title": {
+    "message": "Passwort-Synchronisierung ist nicht verfügbar."
+  },
+  "opt_no_password_body": {
+    "message": "Browser-Erweiterungen können nicht auf den nativen Passwortspeicher zugreifen."
+  },
+  "opt_no_password_use": {
+    "message": "Verwende für selbst gehostete Passwort-Synchronisierung $MANAGERS$.",
+    "placeholders": {
+      "managers": {
+        "content": "$1",
+        "example": "Bitwarden or Proton Pass"
+      }
+    }
+  },
+  "opt_or": {
+    "message": "oder"
+  },
+  "opt_device_head": {
+    "message": "Gerät"
+  },
+  "opt_device_head_sub": {
+    "message": "So identifizierst du dieses Gerät in der Synchronisierung."
+  },
+  "opt_identity_section": {
+    "message": "Identität"
+  },
+  "opt_device_name_label": {
+    "message": "Gerätename"
+  },
+  "opt_device_name_desc": {
+    "message": "So erscheint dieses Gerät in den Synchronisierungsprotokollen."
+  },
+  "opt_device_name_placeholder": {
+    "message": "Mein Laptop"
+  },
+  "opt_device_id_label": {
+    "message": "Geräte-ID"
+  },
+  "opt_device_id_desc": {
+    "message": "Automatisch erzeugt. Nicht ändern."
+  },
+  "opt_behavior_section": {
+    "message": "Synchronisierungsverhalten"
+  },
+  "opt_sync_on_change_label": {
+    "message": "Bei Änderung synchronisieren"
+  },
+  "opt_sync_on_change_desc": {
+    "message": "Synchronisiert Lesezeichen und Tabs sofort, wenn sie sich ändern. Empfohlen."
+  },
+  "opt_auto_sync_label": {
+    "message": "Automatische Synchronisierung"
+  },
+  "opt_auto_sync_desc": {
+    "message": "Synchronisiert außerdem regelmäßig nach Zeitplan."
+  },
+  "opt_notifications_label": {
+    "message": "Benachrichtigungen"
+  },
+  "opt_notifications_desc": {
+    "message": "Synchronisierungsstatus und Konflikthinweise."
+  },
+  "opt_interval_label": {
+    "message": "Synchronisierungsintervall"
+  },
+  "opt_interval_desc": {
+    "message": "Wie oft dieses Gerät entfernte Änderungen abruft. 30 Sekunden sind das Minimum des Browsers für Hintergrundprüfungen. Deine eigenen Änderungen werden fast sofort hochgeladen."
+  },
+  "opt_interval_value": {
+    "message": "$COUNT$ s",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "30"
+      }
+    }
+  },
+  "opt_conflict_section": {
+    "message": "Konfliktlösung"
+  },
+  "opt_conflict_lww": {
+    "message": "Letzte Änderung gewinnt"
+  },
+  "opt_conflict_lww_desc": {
+    "message": "Die neueste Änderung gewinnt immer."
+  },
+  "opt_conflict_local": {
+    "message": "Lokal bevorzugen"
+  },
+  "opt_conflict_local_desc": {
+    "message": "Lokale Änderungen überschreiben entfernte."
+  },
+  "opt_conflict_remote": {
+    "message": "Entfernt bevorzugen"
+  },
+  "opt_conflict_remote_desc": {
+    "message": "Entfernte Änderungen überschreiben lokale."
+  },
+  "opt_conflict_manual": {
+    "message": "Manuell"
+  },
+  "opt_conflict_manual_desc": {
+    "message": "Frag mich bei jedem Konflikt im Popup."
+  },
+  "opt_safety_section": {
+    "message": "Sicherheit"
+  },
+  "opt_bulk_delete_label": {
+    "message": "Maximale Massenlöschung von einem Gerät"
+  },
+  "opt_bulk_delete_desc": {
+    "message": "Ein Sicherheitsnetz: Würden die Löschungen eines anderen Geräts mehr als diesen Anteil deiner lokalen Lesezeichen entfernen, überspringt die Zusammenführung sie (das schützt deinen Baum vor einer fehlerhaften Synchronisierung). Erhöhe den Wert, wenn du regelmäßig in großen Mengen löschst."
+  },
+  "opt_activity_head": {
+    "message": "Aktivität"
+  },
+  "opt_activity_head_sub": {
+    "message": "Was Konode auf diesem Gerät getan hat und womit es arbeitet. Alles wird hier berechnet: die Zahlen, die Wiederherstellungspunkte und die letzten 200 Protokolleinträge sind lokal, und von dieser Seite wird nie etwas hochgeladen."
+  },
+  "opt_sync_activity_section": {
+    "message": "Synchronisierungsaktivität"
+  },
+  "opt_stat_transferred": {
+    "message": "Übertragene Daten"
+  },
+  "opt_stat_runs": {
+    "message": "Synchronisierungen"
+  },
+  "opt_stat_last_sync": {
+    "message": "Letzte Synchronisierung"
+  },
+  "opt_devices_section": {
+    "message": "Geräte"
+  },
+  "opt_devices_section_sub": {
+    "message": "Jedes Gerät mit Dateien in deinem Synchronisierungsordner und was es zuletzt hochgeladen hat. Ein Gerät zu vergessen löscht seine Dateien aus deinem Speicher. Es entfernt in keinem Browser Lesezeichen."
+  },
+  "opt_forget_result_one": {
+    "message": "Eine Datei von $LABEL$ gelöscht. Wenn dieser Browser noch läuft, lädt er sich innerhalb einer Minute erneut hoch und erscheint hier wieder. Das ist kein Fehler: Um ein Gerät draußen zu halten, schalte Konode dort zuerst aus und vergiss es dann hier.",
+    "placeholders": {
+      "label": {
+        "content": "$2",
+        "example": "Work laptop"
+      }
+    }
+  },
+  "opt_forget_result_other": {
+    "message": "$COUNT$ Dateien von $LABEL$ gelöscht. Wenn dieser Browser noch läuft, lädt er sich innerhalb einer Minute erneut hoch und erscheint hier wieder. Das ist kein Fehler: Um ein Gerät draußen zu halten, schalte Konode dort zuerst aus und vergiss es dann hier.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "3"
+      },
+      "label": {
+        "content": "$2",
+        "example": "Work laptop"
+      }
+    }
+  },
+  "opt_dismiss": {
+    "message": "Ausblenden"
+  },
+  "opt_devices_error": {
+    "message": "Deine Geräte konnten nicht gelesen werden: $ERROR$. Das bedeutet nicht, dass du keine hast. Prüfe die Verbindung unter Speicher und öffne diesen Tab erneut.",
+    "placeholders": {
+      "error": {
+        "content": "$1",
+        "example": "404 Not Found"
+      }
+    }
+  },
+  "opt_devices_loading": {
+    "message": "Synchronisierungsordner wird gelesen…"
+  },
+  "opt_devices_empty": {
+    "message": "Noch nichts im Ordner. Führe eine Synchronisierung aus, dann erscheint dieses Gerät."
+  },
+  "opt_device_unnamed": {
+    "message": "Unbenanntes Gerät ($ID$)",
+    "placeholders": {
+      "id": {
+        "content": "$1",
+        "example": "a1b2c3d4"
+      }
+    }
+  },
+  "opt_this_device": {
+    "message": "DIESES GERÄT"
+  },
+  "opt_last_upload": {
+    "message": "· letzter Upload $WHEN$",
+    "placeholders": {
+      "when": {
+        "content": "$1",
+        "example": "8/9/2026, 10:20:45 AM"
+      }
+    }
+  },
+  "opt_forget": {
+    "message": "Vergessen"
+  },
+  "opt_forget_it": {
+    "message": "Vergessen"
+  },
+  "opt_forget_confirm_one": {
+    "message": "Löscht die eine Datei, die dieses Gerät in deinem Speicher hat ($TYPES$). In keinem Browser werden Lesezeichen entfernt, weder hier noch dort. Wenn dieser Browser noch läuft, lädt er sich erneut hoch und erscheint wieder; um ihn draußen zu halten, schalte Konode dort zuerst aus.",
+    "placeholders": {
+      "types": {
+        "content": "$2",
+        "example": "Bookmarks, Sessions"
+      }
+    }
+  },
+  "opt_forget_confirm_other": {
+    "message": "Löscht die $COUNT$ Dateien, die dieses Gerät in deinem Speicher hat ($TYPES$). In keinem Browser werden Lesezeichen entfernt, weder hier noch dort. Wenn dieser Browser noch läuft, lädt er sich erneut hoch und erscheint wieder; um ihn draußen zu halten, schalte Konode dort zuerst aus.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "4"
+      },
+      "types": {
+        "content": "$2",
+        "example": "Bookmarks, Sessions"
+      }
+    }
+  },
+  "opt_that_device": {
+    "message": "dieses Gerät"
+  },
+  "opt_cancel": {
+    "message": "Abbrechen"
+  },
+  "opt_snapshots_section": {
+    "message": "Wiederherstellungspunkte"
+  },
+  "opt_snapshots_section_sub": {
+    "message": "Mit Zeitstempel versehene Kopien deiner Lesezeichen im Speicher, die alle deine Geräte teilen. Eine Wiederherstellung fügt auf diesem Gerät fehlende Lesezeichen wieder hinzu (sie löscht nie). Die neuesten 10 bleiben erhalten, ältere werden automatisch entfernt, und du kannst hier jeden davon löschen."
+  },
+  "opt_snap_now_label": {
+    "message": "Jetzt einen Wiederherstellungspunkt speichern"
+  },
+  "opt_snap_now_desc": {
+    "message": "Ein Wiederherstellungspunkt deines aktuellen Lesezeichenbaums."
+  },
+  "opt_snap_create": {
+    "message": "Erstellen"
+  },
+  "opt_snap_loading": {
+    "message": "Wiederherstellungspunkte werden geladen…"
+  },
+  "opt_snap_error": {
+    "message": "Deine Wiederherstellungspunkte konnten nicht gelesen werden: $ERROR$",
+    "placeholders": {
+      "error": {
+        "content": "$1",
+        "example": "404 Not Found"
+      }
+    }
+  },
+  "opt_snap_error_desc": {
+    "message": "Das bedeutet nicht, dass du keine hast. Sie liegen in deinem Speicher und konnten gerade nicht aufgelistet werden. Prüfe die Verbindung unter Speicher und öffne diesen Tab erneut."
+  },
+  "opt_snap_empty": {
+    "message": "Noch keine Wiederherstellungspunkte. Erstelle oben einen, oder es wird automatisch einer gespeichert, falls jemals eine ungewöhnliche Löschung blockiert wird."
+  },
+  "opt_snap_count_one": {
+    "message": "$COUNT$ Lesezeichen",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "1"
+      }
+    }
+  },
+  "opt_snap_count_other": {
+    "message": "$COUNT$ Lesezeichen",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "412"
+      }
+    }
+  },
+  "opt_snap_unknown": {
+    "message": "Lesezeichen-Wiederherstellungspunkt"
+  },
+  "opt_snap_confirm_restore": {
+    "message": "Wiederherstellen bestätigen"
+  },
+  "opt_snap_confirm_delete": {
+    "message": "Löschen bestätigen"
+  },
+  "opt_snap_delete_aria": {
+    "message": "Diesen Wiederherstellungspunkt löschen"
+  },
+  "opt_log_section": {
+    "message": "Protokoll"
+  },
+  "opt_log_empty_sub": {
+    "message": "Noch keine Einträge."
+  },
+  "opt_log_count_one": {
+    "message": "$COUNT$ Eintrag",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "1"
+      }
+    }
+  },
+  "opt_log_count_other": {
+    "message": "$COUNT$ Einträge",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "200"
+      }
+    }
+  },
+  "opt_log_errors": {
+    "message": " · $COUNT$ mit Fehlern",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "3"
+      }
+    }
+  },
+  "opt_log_skipped": {
+    "message": " · $COUNT$ übersprungen",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      }
+    }
+  },
+  "opt_log_errors_only_label": {
+    "message": "Nur Fehler anzeigen"
+  },
+  "opt_log_errors_only_desc": {
+    "message": "Erfolgreiche Einträge ausblenden."
+  },
+  "opt_log_clear": {
+    "message": "Protokoll löschen"
+  },
+  "opt_log_nothing": {
+    "message": "Noch nichts protokolliert. Führe eine Synchronisierung aus, dann erscheint sie hier."
+  },
+  "opt_log_no_errors": {
+    "message": "Keine Fehler protokolliert. Sehr gut."
+  },
+  "opt_encryption_section": {
+    "message": "Verschlüsselung"
+  },
+  "opt_e2ee_desc": {
+    "message": "AES-256-GCM. Daten werden mit deiner Passphrase verschlüsselt, bevor sie dieses Gerät verlassen, der Speicheranbieter kann sie also nie lesen. Bewahre die Passphrase sicher auf: ohne sie sind verschlüsselte Daten nicht wiederherstellbar, und jedes Gerät muss dieselbe verwenden."
+  },
+  "opt_e2ee_disable_confirm": {
+    "message": "Verschlüsselung ausschalten? Deine synchronisierten Daten werden ab der nächsten Synchronisierung $UNENCRYPTED$ in deinem Speicher abgelegt. Jedes Gerät muss sie dann ebenfalls ausschalten.",
+    "placeholders": {
+      "unencrypted": {
+        "content": "$1",
+        "example": "unencrypted"
+      }
+    }
+  },
+  "opt_unencrypted": {
+    "message": "unverschlüsselt"
+  },
+  "opt_e2ee_turn_off": {
+    "message": "Ausschalten"
+  },
+  "opt_passphrase_label": {
+    "message": "Passphrase"
+  },
+  "opt_passphrase_desc": {
+    "message": "Daraus wird der Verschlüsselungsschlüssel abgeleitet. Wird nur auf diesem Gerät gespeichert und nie hochgeladen."
+  },
+  "opt_passphrase_placeholder": {
+    "message": "Wähle eine starke Passphrase"
+  },
+  "opt_passphrase_confirm_placeholder": {
+    "message": "Passphrase bestätigen"
+  },
+  "opt_passphrase_match": {
+    "message": "Die Passphrasen stimmen überein."
+  },
+  "opt_genkey_saved_warning": {
+    "message": "Speichere das jetzt. Es ist der einzige Weg, deine Daten wiederherzustellen, wenn du sie vergisst. Gib denselben Schlüssel auf deinen anderen Geräten ein."
+  },
+  "opt_e2ee_no_passphrase": {
+    "message": "Die Verschlüsselung ist aktiv, aber es ist keine Passphrase gesetzt, daher lädt die Synchronisierung weiterhin Klartext hoch, bis du eine hinzufügst."
+  },
+  "opt_e2ee_off_warning": {
+    "message": "Die Verschlüsselung ist aus, deine synchronisierten Daten (Lesezeichen, Verlauf, Sitzungen, Erweiterungen) liegen also $UNENCRYPTED$ in deinem Speicher. Schalte sie ein, um alles zu verschlüsseln, bevor es dieses Gerät verlässt.",
+    "placeholders": {
+      "unencrypted": {
+        "content": "$1",
+        "example": "unencrypted"
+      }
+    }
+  },
+  "opt_advanced_head": {
+    "message": "Erweitert"
+  },
+  "opt_advanced_head_sub": {
+    "message": "Backups, Feedback und Entwickleroptionen."
+  },
+  "opt_impexp_section": {
+    "message": "Import / Export"
+  },
+  "opt_export_label": {
+    "message": "Backup exportieren"
+  },
+  "opt_export_desc": {
+    "message": "Lade Lesezeichen, Verlauf und Erweiterungen als JSON-Datei herunter. Ohne Cloud."
+  },
+  "opt_export": {
+    "message": "Exportieren"
+  },
+  "opt_exported": {
+    "message": "Exportiert"
+  },
+  "opt_export_failed": {
+    "message": "Fehlgeschlagen"
+  },
+  "opt_import_label": {
+    "message": "Backup importieren"
+  },
+  "opt_import_desc": {
+    "message": "Aus einem Konode-JSON-Backup wiederherstellen. Lesezeichen landen in einem neuen Ordner."
+  },
+  "opt_import_bad_file": {
+    "message": "Ungültiges oder nicht unterstütztes Dateiformat."
+  },
+  "opt_import_ok_one": {
+    "message": "✓ $COUNT$ Lesezeichen in den Ordner $FOLDER$ importiert.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "1"
+      },
+      "folder": {
+        "content": "$2",
+        "example": "Konode Import"
+      }
+    }
+  },
+  "opt_import_ok_other": {
+    "message": "✓ $COUNT$ Lesezeichen in den Ordner $FOLDER$ importiert.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "412"
+      },
+      "folder": {
+        "content": "$2",
+        "example": "Konode Import"
+      }
+    }
+  },
+  "opt_import": {
+    "message": "Importieren"
+  },
+  "opt_import_done": {
+    "message": "Fertig"
+  },
+  "opt_import_error": {
+    "message": "Fehler"
+  },
+  "opt_feedback_section": {
+    "message": "Feedback"
+  },
+  "opt_feedback_section_sub": {
+    "message": "Es wird nichts automatisch gesendet. Diese öffnen sich nur, wenn du sie anklickst."
+  },
+  "opt_report_label": {
+    "message": "Fehler melden oder Funktion vorschlagen"
+  },
+  "opt_report_desc": {
+    "message": "Öffnet die GitHub-Issues des Projekts (öffentlich, mit deinem GitHub-Konto verknüpft)."
+  },
+  "opt_open_issues": {
+    "message": "Issues öffnen"
+  },
+  "opt_email_label": {
+    "message": "Schreib uns"
+  },
+  "opt_email_desc": {
+    "message": "Für alles, was du nicht öffentlich posten möchtest."
+  },
+  "opt_developer_section": {
+    "message": "Entwickler"
+  },
+  "opt_debug_label": {
+    "message": "Debug-Modus"
+  },
+  "opt_debug_desc": {
+    "message": "Ausführliche Protokollierung in die Browser-Konsole und in Aktivität, damit du sie teilen kannst. Schalte ihn aus, wenn du fertig bist."
+  },
+  "opt_about_section": {
+    "message": "Über"
+  },
+  "opt_version_label": {
+    "message": "Version"
+  },
+  "opt_source_label": {
+    "message": "Quellcode"
+  },
+  "opt_source_desc": {
+    "message": "Keine Telemetrie. Keine externen Server."
+  },
+  "opt_devices_bad_reply": {
+    "message": "Die Geräteliste konnte nicht gelesen werden."
   }
 }

--- a/public/_locales/de/messages.json
+++ b/public/_locales/de/messages.json
@@ -451,5 +451,170 @@
   },
   "datatype_extensions_desc": {
     "message": "Liste der Erweiterungen, fehlende mit Installationslinks."
+  },
+  "opt_secret_copy": {
+    "message": "Kopieren"
+  },
+  "opt_secret_copied": {
+    "message": "Kopiert"
+  },
+  "opt_secret_replace": {
+    "message": "Ersetzen"
+  },
+  "opt_webdav_user_label": {
+    "message": "Benutzername"
+  },
+  "opt_webdav_user_placeholder": {
+    "message": "benutzername"
+  },
+  "opt_webdav_pass_label": {
+    "message": "Passwort / App-Token"
+  },
+  "opt_webdav_http_warn": {
+    "message": "Das ist eine $SCHEME$-Adresse, dein Passwort würde also unverschlüsselt übertragen.",
+    "placeholders": {
+      "scheme": {
+        "content": "$1",
+        "example": "http://"
+      }
+    }
+  },
+  "opt_webdav_http_use": {
+    "message": "Verwende $SCHEME$.",
+    "placeholders": {
+      "scheme": {
+        "content": "$1",
+        "example": "https://"
+      }
+    }
+  },
+  "opt_snap_saved": {
+    "message": "Wiederherstellungspunkt gespeichert."
+  },
+  "opt_snap_restored_one": {
+    "message": "$COUNT$ Lesezeichen wiederhergestellt. Wird mit deinen anderen Geräten synchronisiert…",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "1"
+      }
+    }
+  },
+  "opt_snap_restored_other": {
+    "message": "$COUNT$ Lesezeichen wiederhergestellt. Wird mit deinen anderen Geräten synchronisiert…",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "412"
+      }
+    }
+  },
+  "opt_snap_deleted": {
+    "message": "Wiederherstellungspunkt gelöscht."
+  },
+  "opt_err_perms_no_prompt": {
+    "message": "Dieser Browser kann keine Berechtigungsdialoge anzeigen, daher konnte Konode nicht um Zugriff auf deinen WebDAV-Server bitten. Erteile ihn auf der Berechtigungsseite von Konode in den Erweiterungseinstellungen deines Browsers und versuche es dann erneut."
+  },
+  "opt_err_perms_bad_url": {
+    "message": "Konode hat keine verwendbare WebDAV-Adresse, für die es Zugriff anfragen könnte. Prüfe die Server-URL oben."
+  },
+  "opt_err_perms_denied": {
+    "message": "Die Berechtigung für den Zugriff auf den WebDAV-Server wurde nicht erteilt."
+  },
+  "opt_err_pass_too_short": {
+    "message": "Verwende mindestens $MIN$ Zeichen. Synchronisierte Daten lassen sich offline angreifen, eine kurze Passphrase ist also erratbar. Länger ist besser, oder generiere einen Schlüssel.",
+    "placeholders": {
+      "min": {
+        "content": "$1",
+        "example": "12"
+      }
+    }
+  },
+  "opt_err_pass_mismatch": {
+    "message": "Die beiden Passphrasen stimmen nicht überein. Gib sie zur Bestätigung erneut ein, bevor du speicherst."
+  },
+  "opt_saving": {
+    "message": "Wird gespeichert…"
+  },
+  "opt_saved": {
+    "message": "Gespeichert"
+  },
+  "opt_save_changes": {
+    "message": "Änderungen speichern"
+  },
+  "opt_nav_backend": {
+    "message": "Speicher"
+  },
+  "opt_nav_data": {
+    "message": "Datentypen"
+  },
+  "opt_nav_device": {
+    "message": "Gerät"
+  },
+  "opt_nav_activity": {
+    "message": "Aktivität"
+  },
+  "opt_nav_advanced": {
+    "message": "Erweitert"
+  },
+  "opt_setup_title": {
+    "message": "Konode-Einrichtung abschließen"
+  },
+  "opt_setup_step_storage": {
+    "message": "Wähle, wo deine Daten gespeichert werden"
+  },
+  "opt_setup_step_types": {
+    "message": "Wähle aus, was synchronisiert wird"
+  },
+  "opt_backend_head": {
+    "message": "Speicher"
+  },
+  "opt_backend_head_sub": {
+    "message": "Wähle, wo deine Synchronisierungsdaten gespeichert werden. Deine Daten berühren unsere Server nie."
+  },
+  "opt_gdrive_connect_failed": {
+    "message": "Verbindung fehlgeschlagen"
+  },
+  "opt_gdrive_scope_hint": {
+    "message": "Nur der Bereich $SCOPE$, Konode kann also ausschließlich auf selbst erstellte Dateien zugreifen.",
+    "placeholders": {
+      "scope": {
+        "content": "$1",
+        "example": "drive.file"
+      }
+    }
+  },
+  "opt_drive_folder_label": {
+    "message": "Drive-Ordner-ID"
+  },
+  "opt_optional": {
+    "message": "(optional)"
+  },
+  "opt_drive_folder_placeholder": {
+    "message": "Leer lassen, dann wird automatisch ein Ordner „Konode“ erstellt"
+  },
+  "opt_region_label": {
+    "message": "Region"
+  },
+  "opt_webdav_host_label": {
+    "message": "Server-Host"
+  },
+  "opt_webdav_url_label": {
+    "message": "Server-URL"
+  },
+  "opt_github_token_label": {
+    "message": "Persönlicher Zugriffstoken"
+  },
+  "opt_github_repo_label": {
+    "message": "Repository"
+  },
+  "opt_github_branch_label": {
+    "message": "Branch"
+  },
+  "opt_stat_never": {
+    "message": "Nie"
+  },
+  "opt_setup_sub": {
+    "message": "Konode synchronisiert deinen Browser mit einem Speicher, der dir gehört. Es gibt keinen Konode-Server. Zwei kurze Schritte und du bist fertig. (Falls der Einrichtungsassistent in deinem Browser nie geöffnet wurde, kannst du alles direkt hier erledigen.)"
   }
 }

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -509,5 +509,196 @@
   },
   "datatype_extensions_desc": {
     "message": "Extension list, showing missing ones with install links."
+  },
+  "opt_secret_copy": {
+    "message": "Copy",
+    "description": "Tooltip on the button that copies a saved secret (token, password, passphrase) to the clipboard."
+  },
+  "opt_secret_copied": {
+    "message": "Copied",
+    "description": "Replaces opt_secret_copy for a moment after the copy succeeded."
+  },
+  "opt_secret_replace": {
+    "message": "Replace",
+    "description": "Tooltip on the button that clears a saved secret so a new one can be typed. Konode never shows a saved secret in an editable field, so replacing is the only way to change it."
+  },
+  "opt_webdav_user_label": {
+    "message": "Username"
+  },
+  "opt_webdav_user_placeholder": {
+    "message": "username",
+    "description": "Greyed-out example inside the empty username field. Lowercase on purpose, so it reads as an example rather than a filled-in value."
+  },
+  "opt_webdav_pass_label": {
+    "message": "Password / App token",
+    "description": "Most WebDAV servers want an app-specific token here rather than the account password, which is why both words appear."
+  },
+  "opt_webdav_http_warn": {
+    "message": "This is an $SCHEME$ URL, so your password would be sent unencrypted.",
+    "description": "Warning under a WebDAV card whose address would send credentials in the clear. $SCHEME$ is rendered as code and is never translated. Split around the placeholder with tParts, so word order stays yours.",
+    "placeholders": {
+      "scheme": {
+        "content": "$1",
+        "example": "http://"
+      }
+    }
+  },
+  "opt_webdav_http_use": {
+    "message": "Use $SCHEME$.",
+    "description": "Follows opt_webdav_http_warn. $SCHEME$ is rendered as code and is never translated.",
+    "placeholders": {
+      "scheme": {
+        "content": "$1",
+        "example": "https://"
+      }
+    }
+  },
+  "opt_snap_saved": {
+    "message": "Snapshot saved."
+  },
+  "opt_snap_restored_one": {
+    "message": "Restored $COUNT$ bookmark. Syncing to your other devices…",
+    "description": "A restore only ever ADDS bookmarks back, so this number is what was re-added, never what was removed.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "1"
+      }
+    }
+  },
+  "opt_snap_restored_other": {
+    "message": "Restored $COUNT$ bookmarks. Syncing to your other devices…",
+    "description": "Plural form of opt_snap_restored_one. Hungarian keeps the singular after a numeral, so both forms are worded the same there.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "412"
+      }
+    }
+  },
+  "opt_snap_deleted": {
+    "message": "Restore point deleted."
+  },
+  "opt_err_perms_no_prompt": {
+    "message": "This browser can't show permission prompts, so Konode couldn't ask for access to your WebDAV server. Grant it on Konode's permissions screen in your browser's extension settings, then try again.",
+    "description": "Firefox for Android implements no runtime permission prompts. Saying 'you declined' there would blame the user for something they were never asked."
+  },
+  "opt_err_perms_bad_url": {
+    "message": "Konode has no usable WebDAV address to ask for access to. Check the server URL above."
+  },
+  "opt_err_perms_denied": {
+    "message": "Permission to access the WebDAV server was not granted."
+  },
+  "opt_err_pass_too_short": {
+    "message": "Use at least $MIN$ characters. Synced data can be attacked offline, so a short passphrase is guessable. Longer is better, or generate a key.",
+    "description": "Settings' version of onb_pass_too_short. Longer than the onboarding one because here there is room to say what to do about it.",
+    "placeholders": {
+      "min": {
+        "content": "$1",
+        "example": "12"
+      }
+    }
+  },
+  "opt_err_pass_mismatch": {
+    "message": "The two passphrases don't match. Re-enter to confirm before saving."
+  },
+  "opt_saving": {
+    "message": "Saving…"
+  },
+  "opt_saved": {
+    "message": "Saved",
+    "description": "Shown on the Save button for a moment after a write the extension actually confirmed. Never shown for a write that failed."
+  },
+  "opt_save_changes": {
+    "message": "Save changes"
+  },
+  "opt_nav_backend": {
+    "message": "Storage",
+    "description": "Tab in the Settings navigation strip. Keep every nav label short: the strip has to stay legible when the window is narrow. The section heading is a separate key (opt_backend_head), so you can be shorter here than there."
+  },
+  "opt_nav_data": {
+    "message": "Data Types",
+    "description": "Tab in the Settings navigation strip. Keep it short, see opt_nav_backend."
+  },
+  "opt_nav_device": {
+    "message": "Device",
+    "description": "Tab in the Settings navigation strip. Keep it short, see opt_nav_backend."
+  },
+  "opt_nav_activity": {
+    "message": "Activity",
+    "description": "Tab in the Settings navigation strip. Keep it short, see opt_nav_backend."
+  },
+  "opt_nav_advanced": {
+    "message": "Advanced",
+    "description": "Tab in the Settings navigation strip. Keep it short, see opt_nav_backend."
+  },
+  "opt_setup_title": {
+    "message": "Finish setting up Konode",
+    "description": "Card shown at the top of Settings until first-run setup is complete."
+  },
+  "opt_setup_step_storage": {
+    "message": "Choose where your data is stored"
+  },
+  "opt_setup_step_types": {
+    "message": "Pick what to sync"
+  },
+  "opt_backend_head": {
+    "message": "Storage",
+    "description": "Heading of the Storage section. Separate from the nav label opt_nav_backend, which has to fit a narrow strip, so this one can be as long as it needs to be."
+  },
+  "opt_backend_head_sub": {
+    "message": "Choose where your sync data is stored. Your data never touches our servers."
+  },
+  "opt_gdrive_connect_failed": {
+    "message": "Connection failed",
+    "description": "Fallback when Google sign-in throws without a message of its own."
+  },
+  "opt_gdrive_scope_hint": {
+    "message": "Only the $SCOPE$ scope, so Konode can only access files it creates.",
+    "description": "$SCOPE$ is the OAuth scope name drive.file, rendered as code and never translated. Split around the placeholder with tParts.",
+    "placeholders": {
+      "scope": {
+        "content": "$1",
+        "example": "drive.file"
+      }
+    }
+  },
+  "opt_drive_folder_label": {
+    "message": "Drive Folder ID"
+  },
+  "opt_optional": {
+    "message": "(optional)",
+    "description": "Appended to a field label the user can leave empty. Keep the parentheses."
+  },
+  "opt_drive_folder_placeholder": {
+    "message": "Leave blank to auto-create a 'Konode' folder",
+    "description": "'Konode' is the folder name the extension creates. It is data, not copy, so leave the word itself untranslated."
+  },
+  "opt_region_label": {
+    "message": "Region"
+  },
+  "opt_webdav_host_label": {
+    "message": "Server host"
+  },
+  "opt_webdav_url_label": {
+    "message": "Server URL"
+  },
+  "opt_github_token_label": {
+    "message": "Personal Access Token",
+    "description": "GitHub's own name for this credential. If GitHub's interface uses a translated name in your language, match it."
+  },
+  "opt_github_repo_label": {
+    "message": "Repository"
+  },
+  "opt_github_branch_label": {
+    "message": "Branch",
+    "description": "The git branch. Most languages keep the English word here; use whatever git's own interface uses in yours."
+  },
+  "opt_stat_never": {
+    "message": "Never",
+    "description": "Value of the 'Last sync' tile when this device has never completed a sync."
+  },
+  "opt_setup_sub": {
+    "message": "Konode syncs your browser to storage you own. There's no Konode server. Two quick steps and you're done. (If the setup wizard never opened on your browser, you can do everything right here.)"
   }
 }

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -700,5 +700,615 @@
   },
   "opt_setup_sub": {
     "message": "Konode syncs your browser to storage you own. There's no Konode server. Two quick steps and you're done. (If the setup wizard never opened on your browser, you can do everything right here.)"
+  },
+  "opt_data_head": {
+    "message": "Data Types",
+    "description": "Heading of the Data Types tab. Separate from the nav label opt_nav_data, which has to fit a narrow strip."
+  },
+  "opt_data_head_sub": {
+    "message": "Choose what gets synced across your devices."
+  },
+  "opt_data_section": {
+    "message": "Data to sync"
+  },
+  "opt_data_permission_lost": {
+    "message": "Konode doesn't have the permission this needs any more, so it isn't syncing. Switch it off and on again to restore it.",
+    "description": "A browser can revoke an optional permission from its own extension settings without telling the extension, which leaves a data type looking enabled while it syncs nothing."
+  },
+  "opt_history_days_label": {
+    "message": "Days to sync"
+  },
+  "opt_history_days_desc": {
+    "message": "Recommended: 30 days."
+  },
+  "opt_history_days_value": {
+    "message": "$COUNT$d",
+    "description": "The slider's current value, in a narrow space beside it. Abbreviate the unit if your language can; there is not much room.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "30"
+      }
+    }
+  },
+  "opt_history_hint": {
+    "message": "Pages from your other devices are added with the time they arrived, not the time you first visited them, so on Chromium browsers they show up under today rather than the day you were browsing. Firefox keeps the original date.",
+    "description": "Chrome's history.addUrl takes no visit time; Firefox's does and Konode passes it. Without this note a working sync looks broken."
+  },
+  "opt_missing_ext_head": {
+    "message": "Missing extensions ($COUNT$)",
+    "description": "Heading over the list of extensions your other devices have and this one does not.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "6"
+      }
+    }
+  },
+  "opt_ext_from": {
+    "message": "· from $STORE$",
+    "description": "Which store a missing extension came from. $STORE$ is a brand name (Chrome or Firefox) and is never translated. Keep the leading middle dot, it separates this from the extension's name.",
+    "placeholders": {
+      "store": {
+        "content": "$1",
+        "example": "Firefox"
+      }
+    }
+  },
+  "opt_ext_install": {
+    "message": "Install",
+    "description": "Link on a missing extension that exists in THIS browser's store, so it can be installed directly."
+  },
+  "opt_ext_find": {
+    "message": "Find",
+    "description": "Replaces opt_ext_install when the extension came from the other browser's store: extension IDs don't cross stores, so the link can only run a name search."
+  },
+  "opt_no_password_title": {
+    "message": "Password sync not available."
+  },
+  "opt_no_password_body": {
+    "message": "Browser extensions cannot access the native password store.",
+    "description": "A deliberate security boundary in the browser, not a Konode limitation."
+  },
+  "opt_no_password_use": {
+    "message": "Use $MANAGERS$ for self-hosted password sync.",
+    "description": "$MANAGERS$ is rendered as two product links joined by opt_or, so it is never translated. Split around the placeholder with tParts.",
+    "placeholders": {
+      "managers": {
+        "content": "$1",
+        "example": "Bitwarden or Proton Pass"
+      }
+    }
+  },
+  "opt_or": {
+    "message": "or",
+    "description": "Joins two alternatives that are each their own link, so they cannot be part of one translatable sentence."
+  },
+  "opt_device_head": {
+    "message": "Device",
+    "description": "Heading of the Device tab. Separate from the nav label opt_nav_device, which has to fit a narrow strip."
+  },
+  "opt_device_head_sub": {
+    "message": "Identify this device in the sync network."
+  },
+  "opt_identity_section": {
+    "message": "Identity"
+  },
+  "opt_device_name_label": {
+    "message": "Device name"
+  },
+  "opt_device_name_desc": {
+    "message": "How this device appears in sync logs."
+  },
+  "opt_device_name_placeholder": {
+    "message": "My Laptop",
+    "description": "Example device name in the empty field. Use something ordinary in your language, it is only an example."
+  },
+  "opt_device_id_label": {
+    "message": "Device ID"
+  },
+  "opt_device_id_desc": {
+    "message": "Auto-generated. Do not change.",
+    "description": "Every synced file is named after this id, so a new one would orphan the old files."
+  },
+  "opt_behavior_section": {
+    "message": "Sync behavior"
+  },
+  "opt_sync_on_change_label": {
+    "message": "Sync on change"
+  },
+  "opt_sync_on_change_desc": {
+    "message": "Instantly sync bookmarks and tabs when they change. Recommended."
+  },
+  "opt_auto_sync_label": {
+    "message": "Auto sync"
+  },
+  "opt_auto_sync_desc": {
+    "message": "Also sync on a regular schedule."
+  },
+  "opt_notifications_label": {
+    "message": "Notifications"
+  },
+  "opt_notifications_desc": {
+    "message": "Sync status and conflict alerts."
+  },
+  "opt_interval_label": {
+    "message": "Sync interval"
+  },
+  "opt_interval_desc": {
+    "message": "How often this device pulls remote changes. 30s is the browser's minimum for background checks. Your own changes upload almost instantly."
+  },
+  "opt_interval_value": {
+    "message": "$COUNT$s",
+    "description": "The interval slider's current value in seconds, in a narrow space beside it. Abbreviate the unit if your language can.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "30"
+      }
+    }
+  },
+  "opt_conflict_section": {
+    "message": "Conflict resolution"
+  },
+  "opt_conflict_lww": {
+    "message": "Last Write Wins"
+  },
+  "opt_conflict_lww_desc": {
+    "message": "Most recent change always wins."
+  },
+  "opt_conflict_local": {
+    "message": "Prefer Local"
+  },
+  "opt_conflict_local_desc": {
+    "message": "Local changes override remote."
+  },
+  "opt_conflict_remote": {
+    "message": "Prefer Remote"
+  },
+  "opt_conflict_remote_desc": {
+    "message": "Remote changes override local."
+  },
+  "opt_conflict_manual": {
+    "message": "Manual"
+  },
+  "opt_conflict_manual_desc": {
+    "message": "Ask me to resolve each conflict in the popup."
+  },
+  "opt_safety_section": {
+    "message": "Safety"
+  },
+  "opt_bulk_delete_label": {
+    "message": "Max bulk delete from a peer"
+  },
+  "opt_bulk_delete_desc": {
+    "message": "A safety net: if a peer's deletions would remove more than this share of your local bookmarks, the merge skips them (guards against a corrupt sync wiping your tree). Raise it if you routinely delete in bulk."
+  },
+  "opt_activity_head": {
+    "message": "Activity",
+    "description": "Heading of the Activity tab. Separate from the nav label opt_nav_activity, which has to fit a narrow strip."
+  },
+  "opt_activity_head_sub": {
+    "message": "What Konode did on this device, and what it has to work with. All computed here: the numbers, the restore points and the last 200 log entries are local and nothing on this page is ever uploaded."
+  },
+  "opt_sync_activity_section": {
+    "message": "Sync activity"
+  },
+  "opt_stat_transferred": {
+    "message": "Data transferred"
+  },
+  "opt_stat_runs": {
+    "message": "Sync runs"
+  },
+  "opt_stat_last_sync": {
+    "message": "Last sync"
+  },
+  "opt_devices_section": {
+    "message": "Devices"
+  },
+  "opt_devices_section_sub": {
+    "message": "Every device with files in your sync folder, and what each one last uploaded. Forgetting a device deletes its files from your storage. It removes no bookmarks from any browser."
+  },
+  "opt_forget_result_one": {
+    "message": "Deleted one file belonging to $LABEL$. If that browser is still running, it will upload itself again within a minute and reappear here. That is not a fault: to keep a device out, turn Konode off there first, then forget it here.",
+    "description": "$LABEL$ is the device's own name, so it is never translated. $COUNT$ is available as the second substitution but this form does not need it.",
+    "placeholders": {
+      "label": {
+        "content": "$2",
+        "example": "Work laptop"
+      }
+    }
+  },
+  "opt_forget_result_other": {
+    "message": "Deleted $COUNT$ files belonging to $LABEL$. If that browser is still running, it will upload itself again within a minute and reappear here. That is not a fault: to keep a device out, turn Konode off there first, then forget it here.",
+    "description": "Plural of opt_forget_result_one. $LABEL$ is the device's own name and is never translated.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "3"
+      },
+      "label": {
+        "content": "$2",
+        "example": "Work laptop"
+      }
+    }
+  },
+  "opt_dismiss": {
+    "message": "Dismiss"
+  },
+  "opt_devices_error": {
+    "message": "Couldn't read your devices: $ERROR$. This does not mean you have none. Check the connection in Storage and reopen this tab.",
+    "description": "An empty list must never stand in for a list that failed to load. $ERROR$ is the technical message and is not translated.",
+    "placeholders": {
+      "error": {
+        "content": "$1",
+        "example": "404 Not Found"
+      }
+    }
+  },
+  "opt_devices_loading": {
+    "message": "Reading your sync folder…"
+  },
+  "opt_devices_empty": {
+    "message": "Nothing in the folder yet. Run a sync and this device will appear."
+  },
+  "opt_device_unnamed": {
+    "message": "Unnamed device ($ID$)",
+    "description": "Shown when every packet Konode could read for a device came from a build that carried no name. $ID$ is the start of the device id.",
+    "placeholders": {
+      "id": {
+        "content": "$1",
+        "example": "a1b2c3d4"
+      }
+    }
+  },
+  "opt_this_device": {
+    "message": "THIS DEVICE",
+    "description": "Badge marking your own device in the list. Upper case matches the other badges; use whatever reads as a badge in your language."
+  },
+  "opt_last_upload": {
+    "message": "· last upload $WHEN$",
+    "description": "Follows the list of data types on a device row. $WHEN$ is a date already formatted in the browser's own locale. Keep the leading middle dot, it separates this from the types.",
+    "placeholders": {
+      "when": {
+        "content": "$1",
+        "example": "8/9/2026, 10:20:45 AM"
+      }
+    }
+  },
+  "opt_forget": {
+    "message": "Forget",
+    "description": "Button that deletes a device's files from your storage. Deliberately not a bin icon: what goes is a few files in your own folder, not anybody's bookmarks."
+  },
+  "opt_forget_it": {
+    "message": "Forget it",
+    "description": "Confirms the Forget action."
+  },
+  "opt_forget_confirm_one": {
+    "message": "Deletes the one file this device has in your storage ($TYPES$). No bookmarks are removed from any browser, here or there. If that browser is still running it will upload itself again and reappear; to keep it out, turn Konode off there first.",
+    "description": "$TYPES$ is the list of data types, already translated elsewhere and joined with commas.",
+    "placeholders": {
+      "types": {
+        "content": "$2",
+        "example": "Bookmarks, Sessions"
+      }
+    }
+  },
+  "opt_forget_confirm_other": {
+    "message": "Deletes the $COUNT$ files this device has in your storage ($TYPES$). No bookmarks are removed from any browser, here or there. If that browser is still running it will upload itself again and reappear; to keep it out, turn Konode off there first.",
+    "description": "Plural of opt_forget_confirm_one.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "4"
+      },
+      "types": {
+        "content": "$2",
+        "example": "Bookmarks, Sessions"
+      }
+    }
+  },
+  "opt_that_device": {
+    "message": "that device",
+    "description": "Stands in for a device's name in opt_forget_result_* when the device never published one."
+  },
+  "opt_cancel": {
+    "message": "Cancel"
+  },
+  "opt_snapshots_section": {
+    "message": "Restore points"
+  },
+  "opt_snapshots_section_sub": {
+    "message": "Timestamped copies of your bookmarks on the backend, shared by all your devices. Restoring adds back any bookmarks missing on this device (it never deletes). The newest 10 are kept; older ones are removed automatically, and you can delete any of them here."
+  },
+  "opt_snap_now_label": {
+    "message": "Save a snapshot now"
+  },
+  "opt_snap_now_desc": {
+    "message": "A restore point of your current bookmark tree."
+  },
+  "opt_snap_create": {
+    "message": "Create snapshot"
+  },
+  "opt_snap_loading": {
+    "message": "Loading restore points…"
+  },
+  "opt_snap_error": {
+    "message": "Couldn't read your restore points: $ERROR$",
+    "placeholders": {
+      "error": {
+        "content": "$1",
+        "example": "404 Not Found"
+      }
+    }
+  },
+  "opt_snap_error_desc": {
+    "message": "This does not mean you have none. They live on your storage and could not be listed just now. Check the connection in Storage and reopen this tab.",
+    "description": "On a recovery screen, 'you have no backups' is the worst possible thing to say by mistake."
+  },
+  "opt_snap_empty": {
+    "message": "No restore points yet. Create one above, or one is saved automatically if an unusual deletion is ever blocked."
+  },
+  "opt_snap_count_one": {
+    "message": "$COUNT$ bookmark",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "1"
+      }
+    }
+  },
+  "opt_snap_count_other": {
+    "message": "$COUNT$ bookmarks",
+    "description": "Plural of opt_snap_count_one. Hungarian and German keep the same noun form here.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "412"
+      }
+    }
+  },
+  "opt_snap_unknown": {
+    "message": "Bookmark restore point",
+    "description": "Used instead of a count when the shared index could not be read, for instance before a passphrase is set. A bare 'bookmarks' with no number reads as a rendering fault."
+  },
+  "opt_snap_confirm_restore": {
+    "message": "Confirm restore"
+  },
+  "opt_snap_confirm_delete": {
+    "message": "Confirm delete"
+  },
+  "opt_snap_delete_aria": {
+    "message": "Delete this restore point"
+  },
+  "opt_log_section": {
+    "message": "Log"
+  },
+  "opt_log_empty_sub": {
+    "message": "No entries yet."
+  },
+  "opt_log_count_one": {
+    "message": "$COUNT$ entry",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "1"
+      }
+    }
+  },
+  "opt_log_count_other": {
+    "message": "$COUNT$ entries",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "200"
+      }
+    }
+  },
+  "opt_log_errors": {
+    "message": " · $COUNT$ with errors",
+    "description": "Appended after opt_log_count_*. Keep the leading space and middle dot, they separate it from what came before.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "3"
+      }
+    }
+  },
+  "opt_log_skipped": {
+    "message": " · $COUNT$ skipped",
+    "description": "Appended after opt_log_count_* and opt_log_errors. Keep the leading space and middle dot.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      }
+    }
+  },
+  "opt_log_errors_only_label": {
+    "message": "Show errors only"
+  },
+  "opt_log_errors_only_desc": {
+    "message": "Hide successful entries."
+  },
+  "opt_log_clear": {
+    "message": "Clear log"
+  },
+  "opt_log_nothing": {
+    "message": "Nothing logged yet. Run a sync and it'll show up here."
+  },
+  "opt_log_no_errors": {
+    "message": "No errors logged. Nice."
+  },
+  "opt_encryption_section": {
+    "message": "Encryption"
+  },
+  "opt_e2ee_desc": {
+    "message": "AES-256-GCM. Data is encrypted with your passphrase before it leaves this device, so the storage provider can never read it. Keep the passphrase safe: without it, encrypted data can't be recovered, and every device must use the same one."
+  },
+  "opt_e2ee_disable_confirm": {
+    "message": "Turn off encryption? Your synced data will be stored $UNENCRYPTED$ on your backend from the next sync on. Every device must then also turn it off.",
+    "description": "$UNENCRYPTED$ is opt_unencrypted, rendered bold. Split around the placeholder with tParts. Turning E2EE off is a downgrade, which is why it asks.",
+    "placeholders": {
+      "unencrypted": {
+        "content": "$1",
+        "example": "unencrypted"
+      }
+    }
+  },
+  "opt_unencrypted": {
+    "message": "unencrypted",
+    "description": "Rendered bold inside opt_e2ee_disable_confirm and opt_e2ee_off_warning. It is the word carrying the warning, which is why it is emphasised."
+  },
+  "opt_e2ee_turn_off": {
+    "message": "Turn off"
+  },
+  "opt_passphrase_label": {
+    "message": "Passphrase"
+  },
+  "opt_passphrase_desc": {
+    "message": "Derives the encryption key. Stored only on this device, never uploaded."
+  },
+  "opt_passphrase_placeholder": {
+    "message": "Choose a strong passphrase"
+  },
+  "opt_passphrase_confirm_placeholder": {
+    "message": "Confirm passphrase"
+  },
+  "opt_passphrase_match": {
+    "message": "Passphrases match."
+  },
+  "opt_genkey_saved_warning": {
+    "message": "Save this now. It's the only way to recover your data if you forget it. Enter the same key on your other devices."
+  },
+  "opt_e2ee_no_passphrase": {
+    "message": "Encryption is on but no passphrase is set, so sync keeps uploading plaintext until you add one."
+  },
+  "opt_e2ee_off_warning": {
+    "message": "Encryption is off, so your synced data (bookmarks, history, sessions, extensions) is stored $UNENCRYPTED$ on your backend. Turn it on to encrypt everything before it leaves this device.",
+    "description": "$UNENCRYPTED$ is opt_unencrypted, rendered bold. Split around the placeholder with tParts.",
+    "placeholders": {
+      "unencrypted": {
+        "content": "$1",
+        "example": "unencrypted"
+      }
+    }
+  },
+  "opt_advanced_head": {
+    "message": "Advanced",
+    "description": "Heading of the Advanced tab. Separate from the nav label opt_nav_advanced, which has to fit a narrow strip."
+  },
+  "opt_advanced_head_sub": {
+    "message": "Backups, feedback and developer options."
+  },
+  "opt_impexp_section": {
+    "message": "Import / Export"
+  },
+  "opt_export_label": {
+    "message": "Export backup"
+  },
+  "opt_export_desc": {
+    "message": "Download bookmarks, history, and extensions as a JSON file. No cloud needed."
+  },
+  "opt_export": {
+    "message": "Export"
+  },
+  "opt_exported": {
+    "message": "Exported"
+  },
+  "opt_export_failed": {
+    "message": "Failed"
+  },
+  "opt_import_label": {
+    "message": "Import backup"
+  },
+  "opt_import_desc": {
+    "message": "Restore from a Konode JSON backup. Bookmarks added to a new folder."
+  },
+  "opt_import_bad_file": {
+    "message": "Invalid or unsupported file format."
+  },
+  "opt_import_ok_one": {
+    "message": "✓ Imported $COUNT$ bookmark into the $FOLDER$ folder.",
+    "description": "$FOLDER$ is the folder name the import creates. It is data shared across devices, so it is never translated.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "1"
+      },
+      "folder": {
+        "content": "$2",
+        "example": "Konode Import"
+      }
+    }
+  },
+  "opt_import_ok_other": {
+    "message": "✓ Imported $COUNT$ bookmarks into the $FOLDER$ folder.",
+    "description": "Plural of opt_import_ok_one. $FOLDER$ is never translated.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "412"
+      },
+      "folder": {
+        "content": "$2",
+        "example": "Konode Import"
+      }
+    }
+  },
+  "opt_import": {
+    "message": "Import"
+  },
+  "opt_import_done": {
+    "message": "Done"
+  },
+  "opt_import_error": {
+    "message": "Error"
+  },
+  "opt_feedback_section": {
+    "message": "Feedback"
+  },
+  "opt_feedback_section_sub": {
+    "message": "Nothing is sent automatically. These just open when you click them."
+  },
+  "opt_report_label": {
+    "message": "Report a bug or request a feature"
+  },
+  "opt_report_desc": {
+    "message": "Opens the project's GitHub issues (public, tied to your GitHub account)."
+  },
+  "opt_open_issues": {
+    "message": "Open issues"
+  },
+  "opt_email_label": {
+    "message": "Email us"
+  },
+  "opt_email_desc": {
+    "message": "For anything you'd rather not post publicly."
+  },
+  "opt_developer_section": {
+    "message": "Developer"
+  },
+  "opt_debug_label": {
+    "message": "Debug mode"
+  },
+  "opt_debug_desc": {
+    "message": "Verbose logging, to the browser console and to Activity so you can share it. Turn it off when you're done."
+  },
+  "opt_about_section": {
+    "message": "About"
+  },
+  "opt_version_label": {
+    "message": "Version"
+  },
+  "opt_source_label": {
+    "message": "Source code"
+  },
+  "opt_source_desc": {
+    "message": "No telemetry. No external servers."
+  },
+  "opt_devices_bad_reply": {
+    "message": "Couldn't read the device list.",
+    "description": "Reported through opt_devices_error when the extension replies in a shape the page did not expect. An empty list must never stand in for a list that failed to load."
   }
 }

--- a/public/_locales/hu/messages.json
+++ b/public/_locales/hu/messages.json
@@ -451,5 +451,170 @@
   },
   "datatype_extensions_desc": {
     "message": "A bővítmények listája, a hiányzókhoz telepítési linkkel."
+  },
+  "opt_secret_copy": {
+    "message": "Másolás"
+  },
+  "opt_secret_copied": {
+    "message": "Másolva"
+  },
+  "opt_secret_replace": {
+    "message": "Csere"
+  },
+  "opt_webdav_user_label": {
+    "message": "Felhasználónév"
+  },
+  "opt_webdav_user_placeholder": {
+    "message": "felhasználónév"
+  },
+  "opt_webdav_pass_label": {
+    "message": "Jelszó / app-token"
+  },
+  "opt_webdav_http_warn": {
+    "message": "Ez egy $SCHEME$ cím, így a jelszavad titkosítatlanul utazna.",
+    "placeholders": {
+      "scheme": {
+        "content": "$1",
+        "example": "http://"
+      }
+    }
+  },
+  "opt_webdav_http_use": {
+    "message": "Használj $SCHEME$ címet.",
+    "placeholders": {
+      "scheme": {
+        "content": "$1",
+        "example": "https://"
+      }
+    }
+  },
+  "opt_snap_saved": {
+    "message": "Visszaállítási pont elmentve."
+  },
+  "opt_snap_restored_one": {
+    "message": "$COUNT$ könyvjelző visszaállítva. Szinkronizálás a többi eszközödre…",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "1"
+      }
+    }
+  },
+  "opt_snap_restored_other": {
+    "message": "$COUNT$ könyvjelző visszaállítva. Szinkronizálás a többi eszközödre…",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "412"
+      }
+    }
+  },
+  "opt_snap_deleted": {
+    "message": "Visszaállítási pont törölve."
+  },
+  "opt_err_perms_no_prompt": {
+    "message": "Ez a böngésző nem tud engedélykérő ablakot megjeleníteni, ezért a Konode nem tudott hozzáférést kérni a WebDAV-szerveredhez. Add meg a Konode engedélyeinél a böngésző bővítménybeállításaiban, majd próbáld újra."
+  },
+  "opt_err_perms_bad_url": {
+    "message": "A Konode-nak nincs használható WebDAV-címe, amihez hozzáférést kérhetne. Ellenőrizd a fenti szerver-címet."
+  },
+  "opt_err_perms_denied": {
+    "message": "A WebDAV-szerver eléréséhez szükséges engedély nem lett megadva."
+  },
+  "opt_err_pass_too_short": {
+    "message": "Használj legalább $MIN$ karaktert. A szinkronizált adatok offline is támadhatók, ezért a rövid jelmondat kitalálható. A hosszabb jobb, vagy generálj kulcsot.",
+    "placeholders": {
+      "min": {
+        "content": "$1",
+        "example": "12"
+      }
+    }
+  },
+  "opt_err_pass_mismatch": {
+    "message": "A két jelmondat nem egyezik. Írd be újra a megerősítéshez, mielőtt mentesz."
+  },
+  "opt_saving": {
+    "message": "Mentés…"
+  },
+  "opt_saved": {
+    "message": "Mentve"
+  },
+  "opt_save_changes": {
+    "message": "Változások mentése"
+  },
+  "opt_nav_backend": {
+    "message": "Tárhely"
+  },
+  "opt_nav_data": {
+    "message": "Adattípusok"
+  },
+  "opt_nav_device": {
+    "message": "Eszköz"
+  },
+  "opt_nav_activity": {
+    "message": "Aktivitás"
+  },
+  "opt_nav_advanced": {
+    "message": "Speciális"
+  },
+  "opt_setup_title": {
+    "message": "Fejezd be a Konode beállítását"
+  },
+  "opt_setup_step_storage": {
+    "message": "Válaszd ki, hol tároljuk az adataidat"
+  },
+  "opt_setup_step_types": {
+    "message": "Válaszd ki, mi szinkronizálódjon"
+  },
+  "opt_backend_head": {
+    "message": "Tárhely"
+  },
+  "opt_backend_head_sub": {
+    "message": "Válaszd ki, hol tároljuk a szinkronizált adataidat. Az adataid soha nem érintik a szervereinket."
+  },
+  "opt_gdrive_connect_failed": {
+    "message": "A kapcsolódás nem sikerült"
+  },
+  "opt_gdrive_scope_hint": {
+    "message": "Csak a $SCOPE$ engedélykör, így a Konode kizárólag az általa létrehozott fájlokhoz fér hozzá.",
+    "placeholders": {
+      "scope": {
+        "content": "$1",
+        "example": "drive.file"
+      }
+    }
+  },
+  "opt_drive_folder_label": {
+    "message": "Drive mappa-azonosító"
+  },
+  "opt_optional": {
+    "message": "(nem kötelező)"
+  },
+  "opt_drive_folder_placeholder": {
+    "message": "Hagyd üresen, és a Konode létrehoz egy „Konode” mappát"
+  },
+  "opt_region_label": {
+    "message": "Régió"
+  },
+  "opt_webdav_host_label": {
+    "message": "Szerver címe"
+  },
+  "opt_webdav_url_label": {
+    "message": "Szerver URL"
+  },
+  "opt_github_token_label": {
+    "message": "Személyes hozzáférési token"
+  },
+  "opt_github_repo_label": {
+    "message": "Tároló"
+  },
+  "opt_github_branch_label": {
+    "message": "Branch"
+  },
+  "opt_stat_never": {
+    "message": "Soha"
+  },
+  "opt_setup_sub": {
+    "message": "A Konode a böngésződet a saját tárhelyedre szinkronizálja. Nincs Konode-szerver. Két gyors lépés, és készen vagy. (Ha a beállítás-varázsló nem nyílt meg a böngésződben, itt is el tudsz mindent végezni.)"
   }
 }

--- a/public/_locales/hu/messages.json
+++ b/public/_locales/hu/messages.json
@@ -616,5 +616,576 @@
   },
   "opt_setup_sub": {
     "message": "A Konode a böngésződet a saját tárhelyedre szinkronizálja. Nincs Konode-szerver. Két gyors lépés, és készen vagy. (Ha a beállítás-varázsló nem nyílt meg a böngésződben, itt is el tudsz mindent végezni.)"
+  },
+  "opt_data_head": {
+    "message": "Adattípusok"
+  },
+  "opt_data_head_sub": {
+    "message": "Válaszd ki, mi szinkronizálódjon az eszközeid között."
+  },
+  "opt_data_section": {
+    "message": "Szinkronizált adatok"
+  },
+  "opt_data_permission_lost": {
+    "message": "A Konode-nak már nincs meg az ehhez szükséges engedélye, ezért ez nem szinkronizál. Kapcsold ki, majd újra be, hogy visszaálljon."
+  },
+  "opt_history_days_label": {
+    "message": "Szinkronizált napok"
+  },
+  "opt_history_days_desc": {
+    "message": "Javasolt: 30 nap."
+  },
+  "opt_history_days_value": {
+    "message": "$COUNT$ nap",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "30"
+      }
+    }
+  },
+  "opt_history_hint": {
+    "message": "A többi eszközödről érkező oldalak a megérkezésük idejével kerülnek be, nem az első látogatás idejével, ezért Chromium-alapú böngészőkben a mai nap alatt jelennek meg, nem azon a napon, amikor böngésztél. A Firefox megtartja az eredeti dátumot."
+  },
+  "opt_missing_ext_head": {
+    "message": "Hiányzó bővítmények ($COUNT$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "6"
+      }
+    }
+  },
+  "opt_ext_from": {
+    "message": "· innen: $STORE$",
+    "placeholders": {
+      "store": {
+        "content": "$1",
+        "example": "Firefox"
+      }
+    }
+  },
+  "opt_ext_install": {
+    "message": "Telepítés"
+  },
+  "opt_ext_find": {
+    "message": "Keresés"
+  },
+  "opt_no_password_title": {
+    "message": "A jelszó-szinkronizálás nem elérhető."
+  },
+  "opt_no_password_body": {
+    "message": "A böngészőbővítmények nem érik el a böngésző saját jelszótárolóját."
+  },
+  "opt_no_password_use": {
+    "message": "Önállóan üzemeltetett jelszó-szinkronizáláshoz használd ezeket: $MANAGERS$.",
+    "placeholders": {
+      "managers": {
+        "content": "$1",
+        "example": "Bitwarden or Proton Pass"
+      }
+    }
+  },
+  "opt_or": {
+    "message": "vagy"
+  },
+  "opt_device_head": {
+    "message": "Eszköz"
+  },
+  "opt_device_head_sub": {
+    "message": "Így azonosítod ezt az eszközt a szinkronizálásban."
+  },
+  "opt_identity_section": {
+    "message": "Azonosítás"
+  },
+  "opt_device_name_label": {
+    "message": "Eszköz neve"
+  },
+  "opt_device_name_desc": {
+    "message": "Így jelenik meg ez az eszköz a szinkronizálási naplókban."
+  },
+  "opt_device_name_placeholder": {
+    "message": "A laptopom"
+  },
+  "opt_device_id_label": {
+    "message": "Eszköz-azonosító"
+  },
+  "opt_device_id_desc": {
+    "message": "Automatikusan generált. Ne módosítsd."
+  },
+  "opt_behavior_section": {
+    "message": "Szinkronizálás működése"
+  },
+  "opt_sync_on_change_label": {
+    "message": "Szinkronizálás változáskor"
+  },
+  "opt_sync_on_change_desc": {
+    "message": "Azonnal szinkronizálja a könyvjelzőket és lapokat, amikor megváltoznak. Javasolt."
+  },
+  "opt_auto_sync_label": {
+    "message": "Automatikus szinkronizálás"
+  },
+  "opt_auto_sync_desc": {
+    "message": "Rendszeres időzítés szerint is szinkronizál."
+  },
+  "opt_notifications_label": {
+    "message": "Értesítések"
+  },
+  "opt_notifications_desc": {
+    "message": "Szinkronizálási állapot és ütközési figyelmeztetések."
+  },
+  "opt_interval_label": {
+    "message": "Szinkronizálási időköz"
+  },
+  "opt_interval_desc": {
+    "message": "Milyen gyakran töltse le ez az eszköz a távoli változásokat. A 30 másodperc a böngésző minimuma a háttérben futó ellenőrzésekhez. A saját változásaid szinte azonnal feltöltődnek."
+  },
+  "opt_interval_value": {
+    "message": "$COUNT$ mp",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "30"
+      }
+    }
+  },
+  "opt_conflict_section": {
+    "message": "Ütközések feloldása"
+  },
+  "opt_conflict_lww": {
+    "message": "Az utolsó írás győz"
+  },
+  "opt_conflict_lww_desc": {
+    "message": "Mindig a legutóbbi változás győz."
+  },
+  "opt_conflict_local": {
+    "message": "A helyi elsőbbsége"
+  },
+  "opt_conflict_local_desc": {
+    "message": "A helyi változások felülírják a távoliakat."
+  },
+  "opt_conflict_remote": {
+    "message": "A távoli elsőbbsége"
+  },
+  "opt_conflict_remote_desc": {
+    "message": "A távoli változások felülírják a helyieket."
+  },
+  "opt_conflict_manual": {
+    "message": "Kézi"
+  },
+  "opt_conflict_manual_desc": {
+    "message": "Kérdezzen rá minden ütközésre a felugró ablakban."
+  },
+  "opt_safety_section": {
+    "message": "Biztonság"
+  },
+  "opt_bulk_delete_label": {
+    "message": "Másik eszköztől elfogadott törlés felső határa"
+  },
+  "opt_bulk_delete_desc": {
+    "message": "Védőháló: ha egy másik eszköz törlései a helyi könyvjelzőidnek ennél nagyobb részét vinnék el, az összefésülés kihagyja őket (ez védi a könyvjelzőfádat egy hibás szinkronizálástól). Növeld, ha rendszeresen törölsz nagy tételben."
+  },
+  "opt_activity_head": {
+    "message": "Aktivitás"
+  },
+  "opt_activity_head_sub": {
+    "message": "Mit tett a Konode ezen az eszközön, és mivel dolgozik. Minden itt készül: a számok, a visszaállítási pontok és a legutóbbi 200 naplóbejegyzés helyi, és erről az oldalról semmi nem kerül feltöltésre."
+  },
+  "opt_sync_activity_section": {
+    "message": "Szinkronizálási aktivitás"
+  },
+  "opt_stat_transferred": {
+    "message": "Átvitt adat"
+  },
+  "opt_stat_runs": {
+    "message": "Szinkronizálások"
+  },
+  "opt_stat_last_sync": {
+    "message": "Utolsó szinkronizálás"
+  },
+  "opt_devices_section": {
+    "message": "Eszközök"
+  },
+  "opt_devices_section_sub": {
+    "message": "Minden eszköz, aminek fájljai vannak a szinkronizálási mappádban, és hogy melyik mit töltött fel utoljára. Egy eszköz elfelejtése törli a fájljait a tárhelyedről. Egyetlen böngészőből sem távolít el könyvjelzőt."
+  },
+  "opt_forget_result_one": {
+    "message": "Egy fájl törölve, ami ehhez tartozott: $LABEL$. Ha az a böngésző még fut, egy percen belül újra feltölti magát, és ismét megjelenik itt. Ez nem hiba: ha ki akarod tartani, először kapcsold ki ott a Konode-ot, és csak utána felejtsd el itt.",
+    "placeholders": {
+      "label": {
+        "content": "$2",
+        "example": "Work laptop"
+      }
+    }
+  },
+  "opt_forget_result_other": {
+    "message": "$COUNT$ fájl törölve, ami ehhez tartozott: $LABEL$. Ha az a böngésző még fut, egy percen belül újra feltölti magát, és ismét megjelenik itt. Ez nem hiba: ha ki akarod tartani, először kapcsold ki ott a Konode-ot, és csak utána felejtsd el itt.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "3"
+      },
+      "label": {
+        "content": "$2",
+        "example": "Work laptop"
+      }
+    }
+  },
+  "opt_dismiss": {
+    "message": "Elvetés"
+  },
+  "opt_devices_error": {
+    "message": "Nem sikerült beolvasni az eszközeidet: $ERROR$. Ez nem azt jelenti, hogy nincs egy sem. Ellenőrizd a kapcsolatot a Tárhely fülön, és nyisd meg újra ezt a fület.",
+    "placeholders": {
+      "error": {
+        "content": "$1",
+        "example": "404 Not Found"
+      }
+    }
+  },
+  "opt_devices_loading": {
+    "message": "Szinkronizálási mappa beolvasása…"
+  },
+  "opt_devices_empty": {
+    "message": "A mappa még üres. Futtass egy szinkronizálást, és ez az eszköz megjelenik."
+  },
+  "opt_device_unnamed": {
+    "message": "Névtelen eszköz ($ID$)",
+    "placeholders": {
+      "id": {
+        "content": "$1",
+        "example": "a1b2c3d4"
+      }
+    }
+  },
+  "opt_this_device": {
+    "message": "EZ AZ ESZKÖZ"
+  },
+  "opt_last_upload": {
+    "message": "· utolsó feltöltés: $WHEN$",
+    "placeholders": {
+      "when": {
+        "content": "$1",
+        "example": "8/9/2026, 10:20:45 AM"
+      }
+    }
+  },
+  "opt_forget": {
+    "message": "Elfelejtés"
+  },
+  "opt_forget_it": {
+    "message": "Elfelejtem"
+  },
+  "opt_forget_confirm_one": {
+    "message": "Törli azt az egy fájlt, amit ez az eszköz a tárhelyeden tart ($TYPES$). Egyetlen böngészőből sem törlődik könyvjelző, sem itt, sem ott. Ha az a böngésző még fut, újra feltölti magát és megjelenik; ha ki akarod tartani, először kapcsold ki ott a Konode-ot.",
+    "placeholders": {
+      "types": {
+        "content": "$2",
+        "example": "Bookmarks, Sessions"
+      }
+    }
+  },
+  "opt_forget_confirm_other": {
+    "message": "Törli azt a $COUNT$ fájlt, amit ez az eszköz a tárhelyeden tart ($TYPES$). Egyetlen böngészőből sem törlődik könyvjelző, sem itt, sem ott. Ha az a böngésző még fut, újra feltölti magát és megjelenik; ha ki akarod tartani, először kapcsold ki ott a Konode-ot.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "4"
+      },
+      "types": {
+        "content": "$2",
+        "example": "Bookmarks, Sessions"
+      }
+    }
+  },
+  "opt_that_device": {
+    "message": "az az eszköz"
+  },
+  "opt_cancel": {
+    "message": "Mégse"
+  },
+  "opt_snapshots_section": {
+    "message": "Visszaállítási pontok"
+  },
+  "opt_snapshots_section_sub": {
+    "message": "Időbélyeggel ellátott másolatok a könyvjelzőidről a tárhelyeden, az összes eszközöd között megosztva. A visszaállítás visszateszi az ezen az eszközön hiányzó könyvjelzőket (soha nem töröl). A legújabb 10 marad meg, a régebbiek automatikusan törlődnek, és bármelyiket törölheted itt."
+  },
+  "opt_snap_now_label": {
+    "message": "Visszaállítási pont mentése most"
+  },
+  "opt_snap_now_desc": {
+    "message": "Visszaállítási pont a jelenlegi könyvjelzőfádról."
+  },
+  "opt_snap_create": {
+    "message": "Létrehozás"
+  },
+  "opt_snap_loading": {
+    "message": "Visszaállítási pontok betöltése…"
+  },
+  "opt_snap_error": {
+    "message": "Nem sikerült beolvasni a visszaállítási pontjaidat: $ERROR$",
+    "placeholders": {
+      "error": {
+        "content": "$1",
+        "example": "404 Not Found"
+      }
+    }
+  },
+  "opt_snap_error_desc": {
+    "message": "Ez nem azt jelenti, hogy nincs egy sem. A tárhelyeden vannak, csak most nem sikerült listázni őket. Ellenőrizd a kapcsolatot a Tárhely fülön, és nyisd meg újra ezt a fület."
+  },
+  "opt_snap_empty": {
+    "message": "Még nincs visszaállítási pont. Készíts egyet fent, vagy automatikusan mentődik, ha a Konode egyszer blokkol egy szokatlan törlést."
+  },
+  "opt_snap_count_one": {
+    "message": "$COUNT$ könyvjelző",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "1"
+      }
+    }
+  },
+  "opt_snap_count_other": {
+    "message": "$COUNT$ könyvjelző",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "412"
+      }
+    }
+  },
+  "opt_snap_unknown": {
+    "message": "Könyvjelző-visszaállítási pont"
+  },
+  "opt_snap_confirm_restore": {
+    "message": "Visszaállítás megerősítése"
+  },
+  "opt_snap_confirm_delete": {
+    "message": "Törlés megerősítése"
+  },
+  "opt_snap_delete_aria": {
+    "message": "Visszaállítási pont törlése"
+  },
+  "opt_log_section": {
+    "message": "Napló"
+  },
+  "opt_log_empty_sub": {
+    "message": "Még nincs bejegyzés."
+  },
+  "opt_log_count_one": {
+    "message": "$COUNT$ bejegyzés",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "1"
+      }
+    }
+  },
+  "opt_log_count_other": {
+    "message": "$COUNT$ bejegyzés",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "200"
+      }
+    }
+  },
+  "opt_log_errors": {
+    "message": " · $COUNT$ hibás",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "3"
+      }
+    }
+  },
+  "opt_log_skipped": {
+    "message": " · $COUNT$ kihagyva",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      }
+    }
+  },
+  "opt_log_errors_only_label": {
+    "message": "Csak a hibák"
+  },
+  "opt_log_errors_only_desc": {
+    "message": "A sikeres bejegyzések elrejtése."
+  },
+  "opt_log_clear": {
+    "message": "Napló törlése"
+  },
+  "opt_log_nothing": {
+    "message": "Még nincs naplózva semmi. Futtass egy szinkronizálást, és itt megjelenik."
+  },
+  "opt_log_no_errors": {
+    "message": "Nincs naplózott hiba. Szép."
+  },
+  "opt_encryption_section": {
+    "message": "Titkosítás"
+  },
+  "opt_e2ee_desc": {
+    "message": "AES-256-GCM. Az adatok a jelmondatoddal titkosítva hagyják el ezt az eszközt, így a tárhelyszolgáltató soha nem tudja elolvasni őket. Őrizd meg a jelmondatot: nélküle a titkosított adatok nem visszanyerhetők, és minden eszközön ugyanazt kell használni."
+  },
+  "opt_e2ee_disable_confirm": {
+    "message": "Kikapcsolod a titkosítást? A szinkronizált adataid a következő szinkronizálástól $UNENCRYPTED$ lesznek a tárhelyeden. Ezután minden eszközön ki kell kapcsolni.",
+    "placeholders": {
+      "unencrypted": {
+        "content": "$1",
+        "example": "unencrypted"
+      }
+    }
+  },
+  "opt_unencrypted": {
+    "message": "titkosítás nélkül"
+  },
+  "opt_e2ee_turn_off": {
+    "message": "Kikapcsolás"
+  },
+  "opt_passphrase_label": {
+    "message": "Jelmondat"
+  },
+  "opt_passphrase_desc": {
+    "message": "Ebből származik a titkosítási kulcs. Csak ezen az eszközön tárolódik, soha nem kerül feltöltésre."
+  },
+  "opt_passphrase_placeholder": {
+    "message": "Válassz erős jelmondatot"
+  },
+  "opt_passphrase_confirm_placeholder": {
+    "message": "Jelmondat megerősítése"
+  },
+  "opt_passphrase_match": {
+    "message": "A jelmondatok egyeznek."
+  },
+  "opt_genkey_saved_warning": {
+    "message": "Mentsd el most. Ez az egyetlen módja, hogy visszanyerd az adataidat, ha elfelejtenéd. Ugyanezt a kulcsot add meg a többi eszközödön is."
+  },
+  "opt_e2ee_no_passphrase": {
+    "message": "A titkosítás be van kapcsolva, de nincs beállítva jelmondat, ezért a szinkronizálás titkosítás nélkül tölt fel, amíg nem adsz meg egyet."
+  },
+  "opt_e2ee_off_warning": {
+    "message": "A titkosítás ki van kapcsolva, ezért a szinkronizált adataid (könyvjelzők, előzmények, munkamenetek, bővítmények) $UNENCRYPTED$ vannak a tárhelyeden. Kapcsold be, hogy minden titkosítva hagyja el ezt az eszközt.",
+    "placeholders": {
+      "unencrypted": {
+        "content": "$1",
+        "example": "unencrypted"
+      }
+    }
+  },
+  "opt_advanced_head": {
+    "message": "Speciális"
+  },
+  "opt_advanced_head_sub": {
+    "message": "Biztonsági mentések, visszajelzés és fejlesztői beállítások."
+  },
+  "opt_impexp_section": {
+    "message": "Importálás / exportálás"
+  },
+  "opt_export_label": {
+    "message": "Mentés exportálása"
+  },
+  "opt_export_desc": {
+    "message": "Töltsd le a könyvjelzőket, előzményeket és bővítményeket JSON-fájlként. Nem kell hozzá felhő."
+  },
+  "opt_export": {
+    "message": "Exportálás"
+  },
+  "opt_exported": {
+    "message": "Exportálva"
+  },
+  "opt_export_failed": {
+    "message": "Nem sikerült"
+  },
+  "opt_import_label": {
+    "message": "Mentés importálása"
+  },
+  "opt_import_desc": {
+    "message": "Visszaállítás Konode JSON-mentésből. A könyvjelzők új mappába kerülnek."
+  },
+  "opt_import_bad_file": {
+    "message": "Érvénytelen vagy nem támogatott fájlformátum."
+  },
+  "opt_import_ok_one": {
+    "message": "✓ $COUNT$ könyvjelző importálva a $FOLDER$ mappába.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "1"
+      },
+      "folder": {
+        "content": "$2",
+        "example": "Konode Import"
+      }
+    }
+  },
+  "opt_import_ok_other": {
+    "message": "✓ $COUNT$ könyvjelző importálva a $FOLDER$ mappába.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "412"
+      },
+      "folder": {
+        "content": "$2",
+        "example": "Konode Import"
+      }
+    }
+  },
+  "opt_import": {
+    "message": "Importálás"
+  },
+  "opt_import_done": {
+    "message": "Kész"
+  },
+  "opt_import_error": {
+    "message": "Hiba"
+  },
+  "opt_feedback_section": {
+    "message": "Visszajelzés"
+  },
+  "opt_feedback_section_sub": {
+    "message": "Semmi nem kerül elküldésre automatikusan. Ezek csak megnyílnak, ha rákattintasz."
+  },
+  "opt_report_label": {
+    "message": "Hibajelentés vagy funkciókérés"
+  },
+  "opt_report_desc": {
+    "message": "Megnyitja a projekt GitHub-issue-jait (nyilvános, a GitHub-fiókodhoz kötve)."
+  },
+  "opt_open_issues": {
+    "message": "Issue-k megnyitása"
+  },
+  "opt_email_label": {
+    "message": "Írj nekünk"
+  },
+  "opt_email_desc": {
+    "message": "Bármihez, amit inkább nem tennél közzé nyilvánosan."
+  },
+  "opt_developer_section": {
+    "message": "Fejlesztői"
+  },
+  "opt_debug_label": {
+    "message": "Hibakeresési mód"
+  },
+  "opt_debug_desc": {
+    "message": "Részletes naplózás a böngésző konzoljába és az Aktivitás fülre, hogy meg tudd osztani. Kapcsold ki, ha végeztél."
+  },
+  "opt_about_section": {
+    "message": "Névjegy"
+  },
+  "opt_version_label": {
+    "message": "Verzió"
+  },
+  "opt_source_label": {
+    "message": "Forráskód"
+  },
+  "opt_source_desc": {
+    "message": "Nincs telemetria. Nincsenek külső szerverek."
+  },
+  "opt_devices_bad_reply": {
+    "message": "Nem sikerült beolvasni az eszközlistát."
   }
 }

--- a/src/options/App.tsx
+++ b/src/options/App.tsx
@@ -203,6 +203,14 @@ function SecretField({
   );
 }
 
+/** The bookmark folder an import creates, and the name the message reports.
+ *
+ *  Deliberately NOT a translated string: it is a folder name, so it travels to every other
+ *  device through the sync. Translating it would give each language a different folder and
+ *  break the one thing the sync exists for. Hoisted to a constant so the folder we create
+ *  and the folder we claim to have created cannot drift apart. */
+const IMPORT_FOLDER_NAME = "Konode Import";
+
 // ─── Nav ──────────────────────────────────────────────────────────────────
 
 type NavSection = "backend" | "data" | "device" | "activity" | "advanced";
@@ -445,7 +453,7 @@ export default function OptionsApp() {
     // restore points learned the hard way. request() already folds an ERROR reply into
     // ok:false, so the only surprise left is a reply of the wrong shape.
     if (r.res.type === "DEVICES") setDevices(r.res.payload);
-    else { setDevicesError("Couldn't read the device list."); setDevices([]); }
+    else { setDevicesError(t("opt_devices_bad_reply")); setDevices([]); }
   }, []);
 
   useEffect(() => {
@@ -568,6 +576,28 @@ export default function OptionsApp() {
   const scopeHint = () => {
     const [before, after] = tParts("opt_gdrive_scope_hint");
     return <>{before}<code>drive.file</code>{after}</>;
+  };
+
+  // The word carrying the warning is emphasised, so it is its own key dropped into the
+  // sentence through tParts — same reason as syncingTo(): word order stays translatable.
+  const boldUnencrypted = (key: string) => {
+    const [before, after] = tParts(key);
+    return <>{before}<b>{t("opt_unencrypted")}</b>{after}</>;
+  };
+
+  // Two links inside one clause, so the pair is the placeholder and opt_or joins them.
+  // Splitting the sentence instead would have hard-coded English word order around them.
+  const passwordManagers = () => {
+    const [before, after] = tParts("opt_no_password_use");
+    return (
+      <>
+        {before}
+        <a href="https://bitwarden.com" target="_blank" rel="noreferrer">Bitwarden</a>
+        {` ${t("opt_or")} `}
+        <a href="https://proton.me/pass" target="_blank" rel="noreferrer">Proton Pass</a>
+        {after}
+      </>
+    );
   };
 
   // Shared WebDAV username + password fields (used by every WebDAV preset card).
@@ -921,7 +951,7 @@ export default function OptionsApp() {
         if (otherId) {
           const importFolder = await browser.bookmarks.create({
             parentId: otherId,
-            title: `Konode Import ${new Date().toLocaleDateString()}`,
+            title: `${IMPORT_FOLDER_NAME} ${new Date().toLocaleDateString()}`,
           });
 
           const walk = async (nodes: chrome.bookmarks.BookmarkTreeNode[], parentId: string) => {
@@ -1364,16 +1394,12 @@ export default function OptionsApp() {
                   whether it can read your data. On Advanced it sat in a drawer with Feedback,
                   Debug mode and About, which undersold one of the reasons to use Konode. */}
               <div className="settings-section">
-                <div className="settings-card-head">Encryption</div>
+                <div className="settings-card-head">{t("opt_encryption_section")}</div>
                 <div className="settings-row">
                   <div className="settings-row-left">
                     <div>
-                      <div className="row-label">End-to-End Encryption</div>
-                      <div className="row-desc">
-                        AES-256-GCM. Data is encrypted with your passphrase before it leaves this
-                        device, so the storage provider can never read it. Keep the passphrase safe:
-                        without it, encrypted data can't be recovered, and every device must use the same one.
-                      </div>
+                      <div className="row-label">{t("common_e2ee")}</div>
+                      <div className="row-desc">{t("opt_e2ee_desc")}</div>
                     </div>
                   </div>
                   <label className="toggle-wrap">
@@ -1398,13 +1424,12 @@ export default function OptionsApp() {
                   <div className="settings-row" style={{ paddingTop: 0 }}>
                     <div className="settings-row-left">
                       <div className="row-desc" style={{ color: "var(--danger)" }}>
-                        Turn off encryption? Your synced data will be stored <b>unencrypted</b> on your
-                        backend from the next sync on. Every device must then also turn it off.
+                        {boldUnencrypted("opt_e2ee_disable_confirm")}
                       </div>
                     </div>
                     <div style={{ display: "flex", gap: 8, flexShrink: 0 }}>
                       <button className="btn-secondary" type="button" onClick={() => setConfirmDisableEnc(false)}>
-                        Cancel
+                        {t("opt_cancel")}
                       </button>
                       <button
                         className="btn-secondary"
@@ -1412,7 +1437,7 @@ export default function OptionsApp() {
                         style={{ color: "var(--danger)", borderColor: "var(--danger)" }}
                         onClick={() => { update({ encryption_enabled: false }); setConfirmDisableEnc(false); }}
                       >
-                        Turn off
+                        {t("opt_e2ee_turn_off")}
                       </button>
                     </div>
                   </div>
@@ -1421,20 +1446,20 @@ export default function OptionsApp() {
                   <div className="settings-row">
                     <div className="settings-row-left">
                       <div>
-                        <div className="row-label">Passphrase</div>
-                        <div className="row-desc">Derives the encryption key. Stored only on this device, never uploaded.</div>
+                        <div className="row-label">{t("opt_passphrase_label")}</div>
+                        <div className="row-desc">{t("opt_passphrase_desc")}</div>
                       </div>
                     </div>
                     <div style={{ width: 220 }}>
                       <SecretField
                         value={settings.encryption_passphrase ?? ""}
-                        placeholder="Choose a strong passphrase"
+                        placeholder={t("opt_passphrase_placeholder")}
                         sensitive
                         onChange={(v) => update({ encryption_passphrase: v })}
                       />
                       {passTooShort && (
                         <div className="row-desc" style={{ marginTop: 4, color: "var(--danger)" }}>
-                          At least {MIN_PASSPHRASE_LENGTH} characters. Synced data can be attacked offline, so short passphrases are guessable.
+                          {t("onb_pass_too_short", String(MIN_PASSPHRASE_LENGTH))}
                         </div>
                       )}
                       {needsPassConfirm && (
@@ -1443,17 +1468,17 @@ export default function OptionsApp() {
                             className="field-input mono"
                             type="password"
                             value={passConfirm}
-                            placeholder="Confirm passphrase"
+                            placeholder={t("opt_passphrase_confirm_placeholder")}
                             autoComplete="off"
                             onChange={(e) => setPassConfirm(e.target.value)}
                           />
                           {passMismatch ? (
                             <div className="row-desc" style={{ marginTop: 4, color: "var(--danger)" }}>
-                              Passphrases don't match yet.
+                              {t("onb_pass_mismatch")}
                             </div>
                           ) : (
                             <div className="row-desc" style={{ marginTop: 4, color: "var(--accent)", display: "flex", alignItems: "center", gap: 4 }}>
-                              <CheckCircle2 size={12} style={{ flexShrink: 0 }} /> Passphrases match.
+                              <CheckCircle2 size={12} style={{ flexShrink: 0 }} /> {t("opt_passphrase_match")}
                             </div>
                           )}
                         </div>
@@ -1462,14 +1487,14 @@ export default function OptionsApp() {
                         type="button"
                         onClick={() => { const k = generateRecoveryKey(); setGenKey(k); update({ encryption_passphrase: k }); }}
                         style={{ marginTop: 8, display: "inline-flex", alignItems: "center", gap: 6, fontSize: 12, color: "var(--accent)", background: "none", border: "none", cursor: "pointer", padding: 0 }}>
-                        <Key size={12} /> Generate a strong key
+                        <Key size={12} /> {t("common_generate_key")}
                       </button>
                       {genKey && (
                         <div className="row-desc" style={{ marginTop: 8, color: "var(--text-primary)" }}>
-                          Save this now. It's the only way to recover your data if you forget it. Enter the same key on your other devices.
+                          {t("opt_genkey_saved_warning")}
                           <div style={{ display: "flex", alignItems: "center", gap: 6, marginTop: 4 }}>
                             <code style={{ userSelect: "all", fontSize: 12, wordBreak: "break-all" }}>{genKey}</code>
-                            <button type="button" title="Copy" onClick={() => navigator.clipboard?.writeText(genKey)}
+                            <button type="button" title={t("opt_secret_copy")} onClick={() => navigator.clipboard?.writeText(genKey)}
                               style={{ background: "none", border: "none", cursor: "pointer", color: "var(--accent)", flexShrink: 0 }}>
                               <Copy size={12} />
                             </button>
@@ -1483,7 +1508,7 @@ export default function OptionsApp() {
                   <div className="settings-row" style={{ paddingTop: 0 }}>
                     <div className="settings-row-left">
                       <div className="row-desc" style={{ color: "var(--danger)" }}>
-                        Encryption is on but no passphrase is set, so sync keeps uploading plaintext until you add one.
+                        {t("opt_e2ee_no_passphrase")}
                       </div>
                     </div>
                   </div>
@@ -1493,8 +1518,7 @@ export default function OptionsApp() {
                     <div className="settings-row-left">
                       <AlertTriangle size={14} className="row-icon" style={{ color: "var(--warn-border)" }} />
                       <div className="row-desc" style={{ color: "var(--warn-text)" }}>
-                        Encryption is off, so your synced data (bookmarks, history, sessions, extensions) is stored
-                        <b> unencrypted</b> on your backend. Turn it on to encrypt everything before it leaves this device.
+                        {boldUnencrypted("opt_e2ee_off_warning")}
                       </div>
                     </div>
                   </div>
@@ -1507,11 +1531,11 @@ export default function OptionsApp() {
           {/* ── DATA TYPES ── */}
           {activeNav === "data" && (
             <div className="section-wrap">
-              <h1 className="page-title">Data Types</h1>
-              <p className="page-subtitle">Choose what gets synced across your devices.</p>
+              <h1 className="page-title">{t("opt_data_head")}</h1>
+              <p className="page-subtitle">{t("opt_data_head_sub")}</p>
 
               <div className="settings-section">
-                <div className="settings-card-head">Data to sync</div>
+                <div className="settings-card-head">{t("opt_data_section")}</div>
                 {DATA_TYPES.map((type) => {
                   // Not implemented by this browser: keep the row, drop the switch, and
                   // put the reason where the description was. A dead toggle that springs
@@ -1533,9 +1557,7 @@ export default function OptionsApp() {
                             && availability[type]?.state === "needs-permission"
                             && typeError?.type !== type && (
                             <div className="error-row" role="alert">
-                              <AlertTriangle size={12} /> Konode doesn't have the permission
-                              this needs any more, so it isn't syncing. Switch it off and on
-                              again to restore it.
+                              <AlertTriangle size={12} /> {t("opt_data_permission_lost")}
                             </div>
                           )}
                           {typeError?.type === type && (
@@ -1563,12 +1585,12 @@ export default function OptionsApp() {
                   only suggest the feature is one setting away. */}
               {availability.history?.state !== "unsupported" && (
               <div className="settings-section">
-                <div className="settings-card-head">History</div>
+                <div className="settings-card-head">{t("datatype_history")}</div>
                 <div className="settings-row">
                   <div className="settings-row-left">
                     <div>
-                      <div className="row-label">Days to sync</div>
-                      <div className="row-desc">Recommended: 30 days.</div>
+                      <div className="row-label">{t("opt_history_days_label")}</div>
+                      <div className="row-desc">{t("opt_history_days_desc")}</div>
                     </div>
                   </div>
                   <div className="slider-wrap">
@@ -1576,7 +1598,7 @@ export default function OptionsApp() {
                       value={settings.history_days_limit}
                       onChange={(e) => update({ history_days_limit: Number(e.target.value) })}
                       className="slider" />
-                    <span className="slider-val">{settings.history_days_limit}d</span>
+                    <span className="slider-val">{t("opt_history_days_value", String(settings.history_days_limit))}</span>
                   </div>
                 </div>
                 {/* Nothing said this anywhere, and it makes a working sync look broken: a
@@ -1584,18 +1606,14 @@ export default function OptionsApp() {
                     concludes the history never arrived. Chrome's history.addUrl takes no
                     visit time (Firefox's does, and we pass it), so on Chromium the arriving
                     page can only be stamped with the moment it arrived. */}
-                <InfoHint>
-                  Pages from your other devices are added with the time they arrived, not the
-                  time you first visited them, so on Chromium browsers they show up under
-                  today rather than the day you were browsing. Firefox keeps the original date.
-                </InfoHint>
+                <InfoHint>{t("opt_history_hint")}</InfoHint>
               </div>
               )}
 
               {missingExtensions.length > 0 && (
                 <>
                   <div className="settings-section">
-                    <div className="settings-card-head">Missing extensions ({missingExtensions.length})</div>
+                    <div className="settings-card-head">{t("opt_missing_ext_head", String(missingExtensions.length))}</div>
                     {missingExtensions.map((ext) => (
                       <div key={ext.id} className="settings-row">
                         <div className="settings-row-left">
@@ -1603,13 +1621,13 @@ export default function OptionsApp() {
                           <div>
                             <div className="row-label">
                               {ext.name}{" "}
-                              <span className="row-desc">· from {inferStore(ext) === "firefox" ? "Firefox" : "Chrome"}</span>
+                              <span className="row-desc">{t("opt_ext_from", inferStore(ext) === "firefox" ? "Firefox" : "Chrome")}</span>
                             </div>
                             {ext.description && <div className="row-desc">{ext.description.slice(0, 80)}</div>}
                           </div>
                         </div>
                         <a href={installOrSearchUrl(ext, currentStore())} target="_blank" rel="noreferrer" className="btn-install">
-                          {inferStore(ext) === currentStore() ? "Install" : "Find"}
+                          {inferStore(ext) === currentStore() ? t("opt_ext_install") : t("opt_ext_find")}
                         </a>
                       </div>
                     ))}
@@ -1620,10 +1638,9 @@ export default function OptionsApp() {
               <div className="notice-warn">
                 <AlertTriangle size={14} />
                 <div>
-                  <strong>Password sync not available.</strong>{" "}
-                  Chrome extensions cannot access the native password store. Use{" "}
-                  <a href="https://bitwarden.com" target="_blank" rel="noreferrer">Bitwarden</a> or{" "}
-                  <a href="https://proton.me/pass" target="_blank" rel="noreferrer">Proton Pass</a> for self-hosted password sync.
+                  <strong>{t("opt_no_password_title")}</strong>{" "}
+                  {t("opt_no_password_body")}{" "}
+                  {passwordManagers()}
                 </div>
               </div>
 
@@ -1633,28 +1650,28 @@ export default function OptionsApp() {
           {/* ── DEVICE ── */}
           {activeNav === "device" && (
             <div className="section-wrap">
-              <h1 className="page-title">Device</h1>
-              <p className="page-subtitle">Identify this device in the sync network.</p>
+              <h1 className="page-title">{t("opt_device_head")}</h1>
+              <p className="page-subtitle">{t("opt_device_head_sub")}</p>
 
               <div className="settings-section">
-                <div className="settings-card-head">Identity</div>
+                <div className="settings-card-head">{t("opt_identity_section")}</div>
                 <div className="settings-row">
                   <div className="settings-row-left">
                     <div>
-                      <div className="row-label">Device name</div>
-                      <div className="row-desc">How this device appears in sync logs.</div>
+                      <div className="row-label">{t("opt_device_name_label")}</div>
+                      <div className="row-desc">{t("opt_device_name_desc")}</div>
                     </div>
                   </div>
                   <input className="field-input-inline"
                     value={settings.device_label}
                     onChange={(e) => update({ device_label: e.target.value })}
-                    placeholder="My Laptop" />
+                    placeholder={t("opt_device_name_placeholder")} />
                 </div>
                 <div className="settings-row">
                   <div className="settings-row-left">
                     <div>
-                      <div className="row-label">Device ID</div>
-                      <div className="row-desc">Auto-generated. Do not change.</div>
+                      <div className="row-label">{t("opt_device_id_label")}</div>
+                      <div className="row-desc">{t("opt_device_id_desc")}</div>
                     </div>
                   </div>
                   <span className="mono-value">{settings.device_id.slice(0, 16)}…</span>
@@ -1662,10 +1679,10 @@ export default function OptionsApp() {
               </div>
 
               <div className="settings-section">
-                <div className="settings-card-head">Sync behavior</div>
+                <div className="settings-card-head">{t("opt_behavior_section")}</div>
                 <div className="settings-row">
                   <div className="settings-row-left">
-                    <div><div className="row-label">Sync on change</div><div className="row-desc">Instantly sync bookmarks and tabs when they change. Recommended.</div></div>
+                    <div><div className="row-label">{t("opt_sync_on_change_label")}</div><div className="row-desc">{t("opt_sync_on_change_desc")}</div></div>
                   </div>
                   <label className="toggle-wrap">
                     <input type="checkbox" className="toggle-input" checked={settings.sync_on_change ?? true}
@@ -1675,7 +1692,7 @@ export default function OptionsApp() {
                 </div>
                 <div className="settings-row">
                   <div className="settings-row-left">
-                    <div><div className="row-label">Auto sync</div><div className="row-desc">Also sync on a regular schedule.</div></div>
+                    <div><div className="row-label">{t("opt_auto_sync_label")}</div><div className="row-desc">{t("opt_auto_sync_desc")}</div></div>
                   </div>
                   <label className="toggle-wrap">
                     <input type="checkbox" className="toggle-input" checked={settings.auto_sync}
@@ -1685,7 +1702,7 @@ export default function OptionsApp() {
                 </div>
                 <div className="settings-row">
                   <div className="settings-row-left">
-                    <div><div className="row-label">Notifications</div><div className="row-desc">Sync status and conflict alerts.</div></div>
+                    <div><div className="row-label">{t("opt_notifications_label")}</div><div className="row-desc">{t("opt_notifications_desc")}</div></div>
                   </div>
                   <label className="toggle-wrap">
                     <input type="checkbox" className="toggle-input" checked={settings.notifications_enabled}
@@ -1695,29 +1712,29 @@ export default function OptionsApp() {
                 </div>
                 <div className="settings-row">
                   <div className="settings-row-left">
-                    <div><div className="row-label">Sync interval</div><div className="row-desc">How often this device pulls remote changes. 30s is the browser's minimum for background checks. Your own changes upload almost instantly.</div></div>
+                    <div><div className="row-label">{t("opt_interval_label")}</div><div className="row-desc">{t("opt_interval_desc")}</div></div>
                   </div>
                   <div className="slider-wrap">
                     <input type="range" min={30} max={600} step={30}
                       value={settings.sync_interval_seconds}
                       onChange={(e) => update({ sync_interval_seconds: Number(e.target.value) })}
                       className="slider" />
-                    <span className="slider-val">{settings.sync_interval_seconds}s</span>
+                    <span className="slider-val">{t("opt_interval_value", String(settings.sync_interval_seconds))}</span>
                   </div>
                 </div>
               </div>
 
               <div className="settings-section">
-                <div className="settings-card-head">Conflict resolution</div>
+                <div className="settings-card-head">{t("opt_conflict_section")}</div>
                 {([
-                  { value: "lww",           label: "Last Write Wins",  desc: "Most recent change always wins." },
-                  { value: "prefer-local",  label: "Prefer Local",     desc: "Local changes override remote." },
-                  { value: "prefer-remote", label: "Prefer Remote",    desc: "Remote changes override local." },
-                  { value: "manual",        label: "Manual",           desc: "Ask me to resolve each conflict in the popup." },
-                ] as const).map(({ value, label, desc }) => (
+                  { value: "lww",           labelKey: "opt_conflict_lww",    descKey: "opt_conflict_lww_desc" },
+                  { value: "prefer-local",  labelKey: "opt_conflict_local",  descKey: "opt_conflict_local_desc" },
+                  { value: "prefer-remote", labelKey: "opt_conflict_remote", descKey: "opt_conflict_remote_desc" },
+                  { value: "manual",        labelKey: "opt_conflict_manual", descKey: "opt_conflict_manual_desc" },
+                ] as const).map(({ value, labelKey, descKey }) => (
                   <label key={value} className="settings-row radio-row">
                     <div className="settings-row-left">
-                      <div><div className="row-label">{label}</div><div className="row-desc">{desc}</div></div>
+                      <div><div className="row-label">{t(labelKey)}</div><div className="row-desc">{t(descKey)}</div></div>
                     </div>
                     {/* The real input stays, hidden, so this is still a radio GROUP to the
                         keyboard and to a screen reader: arrow keys move between options and
@@ -1734,16 +1751,12 @@ export default function OptionsApp() {
               </div>
 
               <div className="settings-section">
-                <div className="settings-card-head">Safety</div>
+                <div className="settings-card-head">{t("opt_safety_section")}</div>
                 <div className="settings-row">
                   <div className="settings-row-left">
                     <div>
-                      <div className="row-label">Max bulk delete from a peer</div>
-                      <div className="row-desc">
-                        A safety net: if a peer's deletions would remove more than this share of
-                        your local bookmarks, the merge skips them (guards against a corrupt sync
-                        wiping your tree). Raise it if you routinely delete in bulk.
-                      </div>
+                      <div className="row-label">{t("opt_bulk_delete_label")}</div>
+                      <div className="row-desc">{t("opt_bulk_delete_desc")}</div>
                     </div>
                   </div>
                   <div className="slider-wrap">
@@ -1770,19 +1783,15 @@ export default function OptionsApp() {
             const noticeCount = audit.filter((e) => e.level === "notice").length;
             return (
               <div className="section-wrap">
-                <h1 className="page-title">Activity</h1>
-                <p className="page-subtitle">
-                  What Konode did on this device, and what it has to work with. All computed
-                  here: the numbers, the restore points and the last 200 log entries are local
-                  and nothing on this page is ever uploaded.
-                </p>
+                <h1 className="page-title">{t("opt_activity_head")}</h1>
+                <p className="page-subtitle">{t("opt_activity_head_sub")}</p>
 
                 <div className="settings-section">
-                  <div className="settings-card-head">Sync activity</div>
+                  <div className="settings-card-head">{t("opt_sync_activity_section")}</div>
                   <div className="stat-grid">
-                    <div className="stat-tile"><div className="stat-value">{formatBytes(syncState?.bytes_transferred ?? 0)}</div><div className="stat-label">Data transferred</div></div>
-                    <div className="stat-tile"><div className="stat-value">{totalSyncRuns}</div><div className="stat-label">Sync runs</div></div>
-                    <div className="stat-tile"><div className="stat-value stat-value-sm">{lastSyncLabel}</div><div className="stat-label">Last sync</div></div>
+                    <div className="stat-tile"><div className="stat-value">{formatBytes(syncState?.bytes_transferred ?? 0)}</div><div className="stat-label">{t("opt_stat_transferred")}</div></div>
+                    <div className="stat-tile"><div className="stat-value">{totalSyncRuns}</div><div className="stat-label">{t("opt_stat_runs")}</div></div>
+                    <div className="stat-tile"><div className="stat-value stat-value-sm">{lastSyncLabel}</div><div className="stat-label">{t("opt_stat_last_sync")}</div></div>
                   </div>
                 </div>
 
@@ -1792,33 +1801,25 @@ export default function OptionsApp() {
                     cost half a day on a field report. */}
                 <div className="settings-section">
                   <div className="settings-card-head">
-                    Devices
-                    <span className="head-sub">
-                      Every device with files in your sync folder, and what each one last
-                      uploaded. Forgetting a device deletes its files from your storage. It
-                      removes no bookmarks from any browser.
-                    </span>
+                    {t("opt_devices_section")}
+                    <span className="head-sub">{t("opt_devices_section_sub")}</span>
                   </div>
                   {forgetResult && (
                     <div className="settings-row">
                       <div className="settings-row-left">
                         <div className="row-desc">
-                          Deleted {forgetResult.removed} {forgetResult.removed === 1 ? "file" : "files"} belonging
-                          to {forgetResult.label}. If that browser is still running, it will upload
-                          itself again within a minute and reappear here. That is not a fault: to
-                          keep a device out, turn Konode off there first, then forget it here.
+                          {plural("opt_forget_result", forgetResult.removed, [String(forgetResult.removed), forgetResult.label])}
                         </div>
                       </div>
                       <button className="btn-secondary" style={{ flexShrink: 0 }}
-                        onClick={() => setForgetResult(null)}>Dismiss</button>
+                        onClick={() => setForgetResult(null)}>{t("opt_dismiss")}</button>
                     </div>
                   )}
                   {devicesError && (
                     <div className="settings-row">
                       <div className="settings-row-left">
                         <div className="row-desc" style={{ color: "var(--danger)" }}>
-                          Couldn't read your devices: {devicesError}. This does not mean you have
-                          none. Check the connection in Storage and reopen this tab.
+                          {t("opt_devices_error", devicesError)}
                         </div>
                       </div>
                     </div>
@@ -1826,14 +1827,14 @@ export default function OptionsApp() {
                   {devices === null && !devicesError && (
                     <div className="settings-row">
                       <div className="settings-row-left">
-                        <div className="row-desc"><Loader2 size={12} className="spin" /> Reading your sync folder…</div>
+                        <div className="row-desc"><Loader2 size={12} className="spin" /> {t("opt_devices_loading")}</div>
                       </div>
                     </div>
                   )}
                   {devices?.length === 0 && !devicesError && (
                     <div className="settings-row">
                       <div className="settings-row-left">
-                        <div className="row-desc">Nothing in the folder yet. Run a sync and this device will appear.</div>
+                        <div className="row-desc">{t("opt_devices_empty")}</div>
                       </div>
                     </div>
                   )}
@@ -1843,12 +1844,12 @@ export default function OptionsApp() {
                         <div className="settings-row-left">
                           <div>
                             <div className="row-label">
-                              {d.label ?? `Unnamed device (${d.device_id.slice(0, 8)})`}
-                              {d.isSelf && <span className="badge-active" style={{ marginLeft: 8 }}>THIS DEVICE</span>}
+                              {d.label ?? t("opt_device_unnamed", d.device_id.slice(0, 8))}
+                              {d.isSelf && <span className="badge-active" style={{ marginLeft: 8 }}>{t("opt_this_device")}</span>}
                             </div>
                             <div className="row-desc">
                               {d.types.join(", ")}
-                              {d.lastSeen && ` · last upload ${new Date(d.lastSeen).toLocaleString()}`}
+                              {d.lastSeen && ` ${t("opt_last_upload", new Date(d.lastSeen).toLocaleString())}`}
                             </div>
                           </div>
                         </div>
@@ -1858,7 +1859,7 @@ export default function OptionsApp() {
                         {!d.isSelf && confirmForget !== d.device_id && (
                           <button className="btn-secondary" disabled={forgetting !== null}
                             onClick={() => setConfirmForget(d.device_id)}>
-                            {forgetting === d.device_id && <Loader2 size={12} className="spin" />} Forget
+                            {forgetting === d.device_id && <Loader2 size={12} className="spin" />} {t("opt_forget")}
                           </button>
                         )}
                       </div>
@@ -1868,18 +1869,14 @@ export default function OptionsApp() {
                         <div className="settings-row">
                           <div className="settings-row-left">
                             <div className="row-desc">
-                              Deletes {d.types.length === 1 ? "the one file" : `the ${d.types.length} files`} this
-                              device has in your storage ({d.types.join(", ")}). No bookmarks are removed
-                              from any browser, here or there. If that browser is still running it will
-                              upload itself again and reappear; to keep it out, turn Konode off there
-                              first.
+                              {plural("opt_forget_confirm", d.types.length, [String(d.types.length), d.types.join(", ")])}
                             </div>
                           </div>
                           <div style={{ display: "flex", gap: 8, flexShrink: 0 }}>
-                            <button className="btn-secondary" onClick={() => setConfirmForget(null)}>Cancel</button>
+                            <button className="btn-secondary" onClick={() => setConfirmForget(null)}>{t("opt_cancel")}</button>
                             <button className="btn-secondary" style={{ color: "var(--danger)" }}
-                              onClick={() => void forgetDevice(d.device_id, d.label ?? "that device")}>
-                              Forget it
+                              onClick={() => void forgetDevice(d.device_id, d.label ?? t("opt_that_device"))}>
+                              {t("opt_forget_it")}
                             </button>
                           </div>
                         </div>
@@ -1891,42 +1888,39 @@ export default function OptionsApp() {
                 {/* ── Restore points ── */}
                 <div className="settings-section">
                   <div className="settings-card-head">
-                    Restore points
-                    <span className="head-sub">Timestamped copies of your bookmarks on the backend, shared by all your devices. Restoring adds back any bookmarks missing on this device (it never deletes). The newest 10 are kept; older ones are removed automatically, and you can delete any of them here.</span>
+                    {t("opt_snapshots_section")}
+                    <span className="head-sub">{t("opt_snapshots_section_sub")}</span>
                   </div>
                   <div className="settings-row">
                     <div className="settings-row-left">
                       <div>
-                        <div className="row-label">Save a snapshot now</div>
-                        <div className="row-desc">A restore point of your current bookmark tree.</div>
+                        <div className="row-label">{t("opt_snap_now_label")}</div>
+                        <div className="row-desc">{t("opt_snap_now_desc")}</div>
                       </div>
                     </div>
                     <div style={{ display: "flex", alignItems: "center", gap: 10, flexShrink: 0 }}>
                       {snapMsg && <span className="row-desc">{snapMsg}</span>}
                       <button className="btn-secondary" onClick={createSnapshot} disabled={snapBusy}>
-                        {snapBusy ? <Loader2 size={12} className="spin" /> : <Camera size={12} />} Create snapshot
+                        {snapBusy ? <Loader2 size={12} className="spin" /> : <Camera size={12} />} {t("opt_snap_create")}
                       </button>
                     </div>
                   </div>
                   {snapLoad === "loading" ? (
                     <div className="settings-row">
-                      <div className="settings-row-left"><div className="row-desc">Loading restore points…</div></div>
+                      <div className="settings-row-left"><div className="row-desc">{t("opt_snap_loading")}</div></div>
                     </div>
                   ) : snapLoad !== "ok" ? (
                     <div className="settings-row">
                       <div className="settings-row-left">
                         <div className="error-row" role="alert">
-                          <AlertTriangle size={12} /> Couldn't read your restore points: {snapLoad}
+                          <AlertTriangle size={12} /> {t("opt_snap_error", snapLoad)}
                         </div>
-                        <div className="row-desc">
-                          This does not mean you have none. They live on your storage and could not be
-                          listed just now. Check the connection in Storage Backend and reopen this tab.
-                        </div>
+                        <div className="row-desc">{t("opt_snap_error_desc")}</div>
                       </div>
                     </div>
                   ) : snapshots.length === 0 ? (
                     <div className="settings-row">
-                      <div className="settings-row-left"><div className="row-desc">No restore points yet. Create one above, or one is saved automatically if an unusual deletion is ever blocked.</div></div>
+                      <div className="settings-row-left"><div className="row-desc">{t("opt_snap_empty")}</div></div>
                     </div>
                   ) : snapshots.map((s) => (
                     <div key={s.name} className="settings-row">
@@ -1937,30 +1931,30 @@ export default function OptionsApp() {
                               (e.g. no passphrase set yet) leaves it unknown, and a bare
                               "bookmarks" with no number reads as a rendering fault. */}
                           <div className="row-desc">
-                            {s.count != null ? `${s.count} bookmark${s.count === 1 ? "" : "s"}` : "Bookmark restore point"}
+                            {s.count != null ? plural("opt_snap_count", s.count) : t("opt_snap_unknown")}
                           </div>
                         </div>
                       </div>
                       {confirmRestore === s.name ? (
                         <div style={{ display: "flex", gap: 8, flexShrink: 0 }}>
-                          <button className="btn-secondary" onClick={() => setConfirmRestore(null)} disabled={snapBusy}>Cancel</button>
+                          <button className="btn-secondary" onClick={() => setConfirmRestore(null)} disabled={snapBusy}>{t("opt_cancel")}</button>
                           <button className="btn-secondary" style={{ color: "var(--accent)", borderColor: "var(--accent)" }} onClick={() => restoreSnapshot(s.name)} disabled={snapBusy}>
-                            {snapBusy ? <Loader2 size={12} className="spin" /> : <RotateCcw size={12} />} Confirm restore
+                            {snapBusy ? <Loader2 size={12} className="spin" /> : <RotateCcw size={12} />} {t("opt_snap_confirm_restore")}
                           </button>
                         </div>
                       ) : confirmDelete === s.name ? (
                         <div style={{ display: "flex", gap: 8, flexShrink: 0 }}>
-                          <button className="btn-secondary" onClick={() => setConfirmDelete(null)} disabled={snapBusy}>Cancel</button>
+                          <button className="btn-secondary" onClick={() => setConfirmDelete(null)} disabled={snapBusy}>{t("opt_cancel")}</button>
                           <button className="btn-secondary" style={{ color: "var(--danger)", borderColor: "var(--danger)" }} onClick={() => deleteSnapshot(s.name)} disabled={snapBusy}>
-                            {snapBusy ? <Loader2 size={12} className="spin" /> : <Trash2 size={12} />} Confirm delete
+                            {snapBusy ? <Loader2 size={12} className="spin" /> : <Trash2 size={12} />} {t("opt_snap_confirm_delete")}
                           </button>
                         </div>
                       ) : (
                         <div style={{ display: "flex", gap: 8, flexShrink: 0 }}>
                           <button className="btn-secondary" onClick={() => setConfirmRestore(s.name)} disabled={snapBusy}>
-                            <RotateCcw size={12} /> Restore
+                            <RotateCcw size={12} /> {t("popup_restore")}
                           </button>
-                          <button className="btn-icon" aria-label="Delete this restore point" title="Delete this restore point" onClick={() => setConfirmDelete(s.name)} disabled={snapBusy}>
+                          <button className="btn-icon" aria-label={t("opt_snap_delete_aria")} title={t("opt_snap_delete_aria")} onClick={() => setConfirmDelete(s.name)} disabled={snapBusy}>
                             <Trash2 size={12} />
                           </button>
                         </div>
@@ -1971,11 +1965,11 @@ export default function OptionsApp() {
 
                 <div className="settings-section">
                   <div className="settings-card-head">
-                    Log
+                    {t("opt_log_section")}
                     <span className="head-sub">
                       {audit.length === 0
-                        ? "No entries yet."
-                        : `${audit.length} entr${audit.length === 1 ? "y" : "ies"}${errorCount ? ` · ${errorCount} with errors` : ""}${noticeCount ? ` · ${noticeCount} skipped` : ""}.`}
+                        ? t("opt_log_empty_sub")
+                        : `${plural("opt_log_count", audit.length)}${errorCount ? t("opt_log_errors", String(errorCount)) : ""}${noticeCount ? t("opt_log_skipped", String(noticeCount)) : ""}.`}
                     </span>
                   </div>
 
@@ -1983,8 +1977,8 @@ export default function OptionsApp() {
                     <div className="settings-row">
                       <div className="settings-row-left">
                         <div>
-                          <div className="row-label">Show errors only</div>
-                          <div className="row-desc">Hide successful entries.</div>
+                          <div className="row-label">{t("opt_log_errors_only_label")}</div>
+                          <div className="row-desc">{t("opt_log_errors_only_desc")}</div>
                         </div>
                       </div>
                       <div style={{ display: "flex", alignItems: "center", gap: 12, flexShrink: 0 }}>
@@ -1995,7 +1989,7 @@ export default function OptionsApp() {
                           <span className="toggle-track"><span className="toggle-thumb" /></span>
                         </label>
                         <button className="btn-secondary" onClick={clearAudit}>
-                          <Trash2 size={12} /> Clear log
+                          <Trash2 size={12} /> {t("opt_log_clear")}
                         </button>
                       </div>
                     </div>
@@ -2006,8 +2000,8 @@ export default function OptionsApp() {
                       <div className="settings-row-left">
                         <div className="row-desc">
                           {audit.length === 0
-                            ? "Nothing logged yet. Run a sync and it'll show up here."
-                            : "No errors logged. Nice."}
+                            ? t("opt_log_nothing")
+                            : t("opt_log_no_errors")}
                         </div>
                       </div>
                     </div>
@@ -2044,41 +2038,41 @@ export default function OptionsApp() {
           {/* ── ADVANCED ── */}
           {activeNav === "advanced" && (
             <div className="section-wrap">
-              <h1 className="page-title">Advanced</h1>
-              <p className="page-subtitle">Backups, feedback and developer options.</p>
+              <h1 className="page-title">{t("opt_advanced_head")}</h1>
+              <p className="page-subtitle">{t("opt_advanced_head_sub")}</p>
 
               <div className="settings-section">
-                <div className="settings-card-head">Import / Export</div>
+                <div className="settings-card-head">{t("opt_impexp_section")}</div>
                 <div className="settings-row">
                   <div className="settings-row-left">
                     <div>
-                      <div className="row-label">Export backup</div>
-                      <div className="row-desc">Download bookmarks, history, and extensions as a JSON file. No cloud needed.</div>
+                      <div className="row-label">{t("opt_export_label")}</div>
+                      <div className="row-desc">{t("opt_export_desc")}</div>
                     </div>
                   </div>
                   <button className="btn-secondary" onClick={exportData}>
-                    {exportStatus === "ok" ? <><CheckCircle2 size={12} /> Exported</> :
-                     exportStatus === "error" ? <><XCircle size={12} /> Failed</> :
-                     "Export"}
+                    {exportStatus === "ok" ? <><CheckCircle2 size={12} /> {t("opt_exported")}</> :
+                     exportStatus === "error" ? <><XCircle size={12} /> {t("opt_export_failed")}</> :
+                     t("opt_export")}
                   </button>
                 </div>
                 <div className="settings-row">
                   <div className="settings-row-left">
                     <div>
-                      <div className="row-label">Import backup</div>
+                      <div className="row-label">{t("opt_import_label")}</div>
                       <div className="row-desc">
                         {importStatus === "ok"
-                          ? `✓ Imported ${importCount} bookmarks into "Konode Import" folder.`
+                          ? plural("opt_import_ok", importCount, [String(importCount), IMPORT_FOLDER_NAME])
                           : importStatus === "error"
-                          ? "Invalid or unsupported file format."
-                          : "Restore from a Konode JSON backup. Bookmarks added to a new folder."}
+                          ? t("opt_import_bad_file")
+                          : t("opt_import_desc")}
                       </div>
                     </div>
                   </div>
                   <label className="btn-secondary" style={{ cursor: "pointer" }}>
-                    {importStatus === "ok" ? <><CheckCircle2 size={12} /> Done</> :
-                     importStatus === "error" ? <><XCircle size={12} /> Error</> :
-                     "Import"}
+                    {importStatus === "ok" ? <><CheckCircle2 size={12} /> {t("opt_import_done")}</> :
+                     importStatus === "error" ? <><XCircle size={12} /> {t("opt_import_error")}</> :
+                     t("opt_import")}
                     <input
                       type="file" accept=".json" style={{ display: "none" }}
                       onChange={(e) => { const f = e.target.files?.[0]; if (f) importData(f); e.target.value = ""; }}
@@ -2089,25 +2083,25 @@ export default function OptionsApp() {
 
               <div className="settings-section">
                 <div className="settings-card-head">
-                  Feedback
-                  <span className="head-sub">Nothing is sent automatically. These just open when you click them.</span>
+                  {t("opt_feedback_section")}
+                  <span className="head-sub">{t("opt_feedback_section_sub")}</span>
                 </div>
                 <div className="settings-row">
                   <div className="settings-row-left">
                     <div>
-                      <div className="row-label">Report a bug or request a feature</div>
-                      <div className="row-desc">Opens the project's GitHub issues (public, tied to your GitHub account).</div>
+                      <div className="row-label">{t("opt_report_label")}</div>
+                      <div className="row-desc">{t("opt_report_desc")}</div>
                     </div>
                   </div>
                   <a className="link-external" href="https://github.com/konabe-studio/konode/issues" target="_blank" rel="noreferrer">
-                    <Github size={12} /> Open issues <ExternalLink size={10} />
+                    <Github size={12} /> {t("opt_open_issues")} <ExternalLink size={10} />
                   </a>
                 </div>
                 <div className="settings-row">
                   <div className="settings-row-left">
                     <div>
-                      <div className="row-label">Email us</div>
-                      <div className="row-desc">For anything you'd rather not post publicly.</div>
+                      <div className="row-label">{t("opt_email_label")}</div>
+                      <div className="row-desc">{t("opt_email_desc")}</div>
                     </div>
                   </div>
                   <a className="link-external" href="mailto:konabe@proton.me">
@@ -2117,10 +2111,10 @@ export default function OptionsApp() {
               </div>
 
               <div className="settings-section">
-                <div className="settings-card-head">Developer</div>
+                <div className="settings-card-head">{t("opt_developer_section")}</div>
                 <div className="settings-row">
                   <div className="settings-row-left">
-                    <div><div className="row-label">Debug mode</div><div className="row-desc">Verbose logging, to the browser console and to Activity so you can share it. Turn it off when you're done.</div></div>
+                    <div><div className="row-label">{t("opt_debug_label")}</div><div className="row-desc">{t("opt_debug_desc")}</div></div>
                   </div>
                   <label className="toggle-wrap">
                     <input type="checkbox" className="toggle-input" checked={settings.debug_mode}
@@ -2131,14 +2125,14 @@ export default function OptionsApp() {
               </div>
 
               <div className="settings-section">
-                <div className="settings-card-head">About</div>
+                <div className="settings-card-head">{t("opt_about_section")}</div>
                 <div className="settings-row">
-                  <div className="settings-row-left"><div><div className="row-label">Version</div></div></div>
+                  <div className="settings-row-left"><div><div className="row-label">{t("opt_version_label")}</div></div></div>
                   <span className="mono-value">{APP_VERSION}</span>
                 </div>
                 <div className="settings-row">
                   <div className="settings-row-left">
-                    <div><div className="row-label">Source code</div><div className="row-desc">No telemetry. No external servers.</div></div>
+                    <div><div className="row-label">{t("opt_source_label")}</div><div className="row-desc">{t("opt_source_desc")}</div></div>
                   </div>
                   <a href="https://github.com/konabe-studio/konode" target="_blank" rel="noreferrer" className="link-external">
                     <Github size={12} /> GitHub <ExternalLink size={10} />

--- a/src/options/App.tsx
+++ b/src/options/App.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, useCallback, useRef, Fragment } from "react";
 import type { SyncSettings, SyncState, BackendType, DataType, BackendConfig, SyncExtension, SnapshotMeta, DeviceInfo } from "@/lib/types";
 import { sendMessage, request } from "@/lib/utils/messaging";
-import { t, tParts } from "@/lib/utils/i18n";
+import { t, tParts, plural } from "@/lib/utils/i18n";
 import { interactiveSignIn, isDriveAuthAvailable } from "@/lib/backends/gdrive-oauth";
 import {
   allDataTypeAvailability, dataTypeAvailability, dataTypeApiPresent, ensurePermission,
@@ -154,7 +154,7 @@ function SecretField({
           <button
             className="btn-eye"
             type="button"
-            title={revealed ? "Hide" : "Show"}
+            title={revealed ? t("common_hide") : t("common_show")}
             onClick={() => setRevealed((v) => !v)}
           >
             {revealed ? <EyeOff size={14} /> : <Eye size={14} />}
@@ -162,7 +162,7 @@ function SecretField({
           <button
             className="btn-eye"
             type="button"
-            title={copied ? "Copied" : "Copy"}
+            title={copied ? t("opt_secret_copied") : t("opt_secret_copy")}
             style={copied ? { color: "var(--accent)" } : undefined}
             onClick={copy}
           >
@@ -171,7 +171,7 @@ function SecretField({
           <button
             className="btn-eye"
             type="button"
-            title="Replace"
+            title={t("opt_secret_replace")}
             onClick={() => { setDraft(""); setRevealed(false); setEditing(true); }}
           >
             <Pencil size={14} />
@@ -194,7 +194,7 @@ function SecretField({
       <button
         className="btn-eye"
         type="button"
-        title={revealed ? "Hide" : "Show"}
+        title={revealed ? t("common_hide") : t("common_show")}
         onClick={() => setRevealed((v) => !v)}
       >
         {revealed ? <EyeOff size={14} /> : <Eye size={14} />}
@@ -213,12 +213,12 @@ const SAVEABLE_TABS = new Set<NavSection>(["backend", "data", "device", "advance
 // Text only. The tab icons were noise: six glyphs competing with six words that
 // already said the same thing, in the one strip that has to stay legible when the
 // window is narrow.
-const NAV: { id: NavSection; label: string }[] = [
-  { id: "backend",  label: "Storage" },
-  { id: "data",     label: "Data Types" },
-  { id: "device",   label: "Device" },
-  { id: "activity", label: "Activity" },
-  { id: "advanced", label: "Advanced" },
+const NAV: { id: NavSection; labelKey: string }[] = [
+  { id: "backend",  labelKey: "opt_nav_backend" },
+  { id: "data",     labelKey: "opt_nav_data" },
+  { id: "device",   labelKey: "opt_nav_device" },
+  { id: "activity", labelKey: "opt_nav_activity" },
+  { id: "advanced", labelKey: "opt_nav_advanced" },
 ];
 
 /** An information box. The icon belongs to the pattern, the same way notice-warn owns
@@ -563,23 +563,30 @@ export default function OptionsApp() {
     return <>{before}<code>{url}</code>{after}</>;
   };
 
+  // Same shape as syncingTo(): one placeholder rendered as <code>, so the scope name stays
+  // a literal and the sentence around it stays the translator's to arrange.
+  const scopeHint = () => {
+    const [before, after] = tParts("opt_gdrive_scope_hint");
+    return <>{before}<code>drive.file</code>{after}</>;
+  };
+
   // Shared WebDAV username + password fields (used by every WebDAV preset card).
   const webdavCreds = () => {
     const w = getBackend("webdav")?.webdav;
     return (
       <div className="field-row-2">
         <div className="field-group" style={{ flex: 1 }}>
-          <label className="field-label">Username</label>
+          <label className="field-label">{t("opt_webdav_user_label")}</label>
           <input
             className="field-input mono"
             value={w?.username ?? ""}
             onChange={(e) => updateBackend("webdav", { webdav: { ...w, username: e.target.value } as any })}
-            placeholder="username"
+            placeholder={t("opt_webdav_user_placeholder")}
             autoComplete="off"
           />
         </div>
         <div className="field-group" style={{ flex: 1 }}>
-          <label className="field-label">Password / App token</label>
+          <label className="field-label">{t("opt_webdav_pass_label")}</label>
           <SecretField
             value={w?.password ?? ""}
             placeholder="••••••••"
@@ -599,7 +606,7 @@ export default function OptionsApp() {
   const createSnapshot = async () => {
     setSnapBusy(true); setSnapMsg(null);
     const res = await sendMessage({ type: "CREATE_SNAPSHOT" });
-    if (res.type === "SNAPSHOTS") { setSnapshots(res.payload); setSnapMsg("Snapshot saved."); }
+    if (res.type === "SNAPSHOTS") { setSnapshots(res.payload); setSnapMsg(t("opt_snap_saved")); }
     else if (res.type === "ERROR") setSnapMsg(res.payload);
     setSnapBusy(false);
   };
@@ -607,7 +614,7 @@ export default function OptionsApp() {
   const restoreSnapshot = async (name: string) => {
     setSnapBusy(true); setSnapMsg(null); setConfirmRestore(null);
     const res = await sendMessage({ type: "RESTORE_SNAPSHOT", payload: { name } });
-    if (res.type === "SNAPSHOT_RESTORED") setSnapMsg(`Restored ${res.payload.restored} bookmark(s). Syncing to your other devices…`);
+    if (res.type === "SNAPSHOT_RESTORED") setSnapMsg(plural("opt_snap_restored", res.payload.restored));
     else if (res.type === "ERROR") setSnapMsg(res.payload);
     setSnapBusy(false);
   };
@@ -615,7 +622,7 @@ export default function OptionsApp() {
   const deleteSnapshot = async (name: string) => {
     setSnapBusy(true); setSnapMsg(null); setConfirmDelete(null);
     const res = await sendMessage({ type: "DELETE_SNAPSHOT", payload: { name } });
-    if (res.type === "SNAPSHOTS") { setSnapshots(res.payload); setSnapMsg("Restore point deleted."); }
+    if (res.type === "SNAPSHOTS") { setSnapshots(res.payload); setSnapMsg(t("opt_snap_deleted")); }
     else if (res.type === "ERROR") setSnapMsg(res.payload);
     setSnapBusy(false);
   };
@@ -624,9 +631,14 @@ export default function OptionsApp() {
   const webdavHttpWarn = () => {
     const u = getBackend("webdav")?.webdav?.url ?? "";
     if (!/^http:\/\//i.test(u) || /^http:\/\/(localhost|127\.)/i.test(u)) return null;
+    // Two sentences, each split around its own scheme, rather than one string with two
+    // inline elements: tParts carries a single placeholder, and the schemes are literals
+    // that never translate, so they stay <code> and word order stays the translator's.
+    const [warnBefore, warnAfter] = tParts("opt_webdav_http_warn");
+    const [useBefore, useAfter] = tParts("opt_webdav_http_use");
     return (
       <div className="error-row">
-        <AlertTriangle size={12} /> This is an <code>http://</code> URL, so your password would be sent unencrypted. Use <code>https://</code>.
+        <AlertTriangle size={12} /> {warnBefore}<code>http://</code>{warnAfter} {useBefore}<code>https://</code>{useAfter}
       </div>
     );
   };
@@ -662,20 +674,20 @@ export default function OptionsApp() {
    *  user is told they refused something they were never asked. */
   const webdavPermissionError = (outcome: PermissionOutcome | "bad-url"): string =>
     outcome === "cannot-prompt"
-      ? "This browser can't show permission prompts, so Konode couldn't ask for access to your WebDAV server. Grant it on Konode's permissions screen in your browser's extension settings, then try again."
+      ? t("opt_err_perms_no_prompt")
       : outcome === "bad-url"
-        ? "Konode has no usable WebDAV address to ask for access to. Check the server URL above."
-        : "Permission to access the WebDAV server was not granted.";
+        ? t("opt_err_perms_bad_url")
+        : t("opt_err_perms_denied");
 
   const save = async () => {
     if (!settings) return;
     setSaveError(null);
     if (passTooShort) {
-      setSaveError(`Use at least ${MIN_PASSPHRASE_LENGTH} characters. Synced data can be attacked offline, so a short passphrase is guessable. Longer is better, or generate a key.`);
+      setSaveError(t("opt_err_pass_too_short", String(MIN_PASSPHRASE_LENGTH)));
       return;
     }
     if (passMismatch) {
-      setSaveError("The two passphrases don't match. Re-enter to confirm before saving.");
+      setSaveError(t("opt_err_pass_mismatch"));
       return;
     }
     if (settings.active_backend === "webdav") {
@@ -719,7 +731,7 @@ export default function OptionsApp() {
     <div className="action-row">
       <div className="action-buttons">
         <button className={`btn-save ${saveOk ? "saved" : ""} ${dirty ? "pending" : ""}`} onClick={save} disabled={saving || opts.disabled}>
-          {saving ? "Saving…" : saveOk ? "Saved" : "Save changes"}
+          {saving ? t("opt_saving") : saveOk ? t("opt_saved") : t("opt_save_changes")}
         </button>
       </div>
       {(saveError || dirty) && (
@@ -816,7 +828,7 @@ export default function OptionsApp() {
       setGdriveUser({ email: s.email, displayName: s.displayName });
       update({ active_backend: "gdrive" });
     } catch (err) {
-      setGdriveError(err instanceof Error ? err.message : "Connection failed");
+      setGdriveError(err instanceof Error ? err.message : t("opt_gdrive_connect_failed"));
     } finally {
       setGdriveConnecting(false);
     }
@@ -1010,7 +1022,7 @@ export default function OptionsApp() {
   const totalSyncRuns = syncState ? Object.values(syncState.sync_counts).reduce((a, b) => a + b, 0) : 0;
   const lastSyncLabel = syncState?.last_sync
     ? new Date(syncState.last_sync).toLocaleString([], { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" })
-    : "Never";
+    : t("opt_stat_never");
 
   return (
     <div className="settings-root">
@@ -1024,14 +1036,14 @@ export default function OptionsApp() {
             <span className="topbar-title">Konode</span>
           </div>
           <nav ref={tabbarFade.ref} className={`tabbar ${tabbarFade.className}`}>
-            {NAV.map(({ id, label }) => (
+            {NAV.map(({ id, labelKey }) => (
               <button
                 key={id}
                 className={`tab-item ${activeNav === id ? "active" : ""}`}
                 onClick={() => setActiveNav(id)}
                 aria-current={activeNav === id ? "page" : undefined}
               >
-                <span>{label}</span>
+                <span>{t(labelKey)}</span>
               </button>
             ))}
           </nav>
@@ -1048,30 +1060,26 @@ export default function OptionsApp() {
               <div className="setup-card-head">
                 <div className="setup-card-mark"><BrandMark size={16} /></div>
                 <div>
-                  <div className="setup-card-title">Finish setting up Konode</div>
-                  <div className="setup-card-sub">
-                    Konode syncs your browser to storage you own. There's no Konode server. Two quick
-                    steps and you're done. (If the setup wizard never opened on your browser, you can do
-                    everything right here.)
-                  </div>
+                  <div className="setup-card-title">{t("opt_setup_title")}</div>
+                  <div className="setup-card-sub">{t("opt_setup_sub")}</div>
                 </div>
               </div>
               <ol className="setup-steps">
                 <li className={activeBackendConfigured ? "done" : ""}>
                   <span className="step-badge">{activeBackendConfigured ? <CheckCircle2 size={14} /> : "1"}</span>
-                  <span className="step-text">Choose where your data is stored</span>
+                  <span className="step-text">{t("opt_setup_step_storage")}</span>
                   {!activeBackendConfigured && (
                     <button className="step-action" onClick={() => setActiveNav("backend")}>
-                      Storage <ArrowRight size={12} />
+                      {t("opt_nav_backend")} <ArrowRight size={12} />
                     </button>
                   )}
                 </li>
                 <li className={settings.enabled_types.length > 0 ? "done" : ""}>
                   <span className="step-badge">{settings.enabled_types.length > 0 ? <CheckCircle2 size={14} /> : "2"}</span>
-                  <span className="step-text">Pick what to sync</span>
+                  <span className="step-text">{t("opt_setup_step_types")}</span>
                   {settings.enabled_types.length === 0 && (
                     <button className="step-action" onClick={() => setActiveNav("data")}>
-                      Data types <ArrowRight size={12} />
+                      {t("opt_nav_data")} <ArrowRight size={12} />
                     </button>
                   )}
                 </li>
@@ -1082,8 +1090,8 @@ export default function OptionsApp() {
           {/* ── BACKEND ── */}
           {activeNav === "backend" && (
             <div className="section-wrap">
-              <h1 className="page-title">Storage</h1>
-              <p className="page-subtitle">Choose where your sync data is stored. Your data never touches our servers.</p>
+              <h1 className="page-title">{t("opt_backend_head")}</h1>
+              <p className="page-subtitle">{t("opt_backend_head_sub")}</p>
 
               <div className="card-list">
                 {PROVIDERS.map((p) => {
@@ -1150,20 +1158,20 @@ export default function OptionsApp() {
                                     <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
                                   </svg>
                                 )}
-                                {gdriveConnecting ? "Connecting…" : "Sign in with Google"}
+                                {gdriveConnecting ? t("onb_connecting") : t("onb_sign_in_google")}
                               </button>
                               {gdriveError && <div className="error-row"><XCircle size={12} /> {gdriveError}</div>}
-                              <InfoHint>Only the <code>drive.file</code> scope, so Konode can only access files it creates.</InfoHint>
+                              <InfoHint>{scopeHint()}</InfoHint>
                             </div>
                           )}
                           {gdriveUser && (
                             <div className="field-group">
-                              <label className="field-label">Drive Folder ID <span className="optional">(optional)</span></label>
+                              <label className="field-label">{t("opt_drive_folder_label")} <span className="optional">{t("opt_optional")}</span></label>
                               <input
                                 className="field-input"
                                 value={getBackend("gdrive")?.gdrive?.folderId ?? ""}
                                 onChange={(e) => updateBackend("gdrive", { gdrive: { folderId: e.target.value } })}
-                                placeholder="Leave blank to auto-create a 'Konode' folder"
+                                placeholder={t("opt_drive_folder_placeholder")}
                               />
                             </div>
                           )}
@@ -1185,7 +1193,7 @@ export default function OptionsApp() {
                       {isActive && p.id === "pcloud" && (
                         <div className="backend-config" onClick={(e) => e.stopPropagation()}>
                           <div className="field-group">
-                            <label className="field-label">Region</label>
+                            <label className="field-label">{t("opt_region_label")}</label>
                             <div className="seg-group">
                               {p.regions!.map((r) => {
                                 const on = pcloudRegionOf(getBackend("webdav")?.webdav?.url) === r.id;
@@ -1217,7 +1225,7 @@ export default function OptionsApp() {
                       {isActive && p.id === "nextcloud" && (
                         <div className="backend-config" onClick={(e) => e.stopPropagation()}>
                           <div className="field-group">
-                            <label className="field-label">Server host</label>
+                            <label className="field-label">{t("opt_webdav_host_label")}</label>
                             <input
                               className="field-input mono"
                               value={nextcloudBaseFromUrl(getBackend("webdav")?.webdav?.url)}
@@ -1229,7 +1237,7 @@ export default function OptionsApp() {
                             />
                           </div>
                           <div className="field-group">
-                            <label className="field-label">Username</label>
+                            <label className="field-label">{t("opt_webdav_user_label")}</label>
                             <input
                               className="field-input mono"
                               value={getBackend("webdav")?.webdav?.username ?? ""}
@@ -1237,12 +1245,12 @@ export default function OptionsApp() {
                                 const w = getBackend("webdav")?.webdav;
                                 updateBackend("webdav", { webdav: { ...w, username: e.target.value, url: nextcloudUrl(nextcloudBaseFromUrl(w?.url), e.target.value) } as any });
                               }}
-                              placeholder="username"
+                              placeholder={t("opt_webdav_user_placeholder")}
                               autoComplete="off"
                             />
                           </div>
                           <div className="field-group">
-                            <label className="field-label">Password / App token</label>
+                            <label className="field-label">{t("opt_webdav_pass_label")}</label>
                             <SecretField
                               value={getBackend("webdav")?.webdav?.password ?? ""}
                               placeholder="••••••••"
@@ -1263,7 +1271,7 @@ export default function OptionsApp() {
                       {isActive && p.id === "webdav" && (
                         <div className="backend-config" onClick={(e) => e.stopPropagation()}>
                           <div className="field-group">
-                            <label className="field-label">Server URL</label>
+                            <label className="field-label">{t("opt_webdav_url_label")}</label>
                             <input
                               className="field-input mono"
                               value={getBackend("webdav")?.webdav?.url ?? ""}
@@ -1280,7 +1288,7 @@ export default function OptionsApp() {
                       {isActive && p.id === "github" && (
                         <div className="backend-config" onClick={(e) => e.stopPropagation()}>
                           <div className="field-group">
-                            <label className="field-label">Personal Access Token</label>
+                            <label className="field-label">{t("opt_github_token_label")}</label>
                             <SecretField
                               value={getBackend("github")?.github?.token ?? ""}
                               placeholder="ghp_xxxxxxxxxxxxxxxxxxxx"
@@ -1290,14 +1298,14 @@ export default function OptionsApp() {
                                 if (v.length > 10) await verifyGithubToken(v);
                               }}
                             />
-                            {githubChecking && <div className="verify-row"><Loader2 size={12} className="spin" /> Verifying…</div>}
+                            {githubChecking && <div className="verify-row"><Loader2 size={12} className="spin" /> {t("onb_verifying")}</div>}
                             {githubUser && !githubChecking && (
                               <div className="verify-row ok"><CheckCircle2 size={12} /> @{githubUser.login} · {githubUser.name}</div>
                             )}
                           </div>
                           <div className="field-row-2">
                             <div className="field-group" style={{ flex: 2 }}>
-                              <label className="field-label">Repository</label>
+                              <label className="field-label">{t("opt_github_repo_label")}</label>
                               <input
                                 className="field-input mono"
                                 value={getBackend("github")?.github?.repo ?? ""}
@@ -1306,7 +1314,7 @@ export default function OptionsApp() {
                               />
                             </div>
                             <div className="field-group" style={{ flex: 1 }}>
-                              <label className="field-label">Branch</label>
+                              <label className="field-label">{t("opt_github_branch_label")}</label>
                               <input
                                 className="field-input mono"
                                 value={getBackend("github")?.github?.branch ?? "main"}


### PR DESCRIPTION
The Settings page was never internationalised, and it is very nearly half the user-visible copy in the extension. So a translation could be 123/123 complete and the biggest screen still read English end to end.

| | before | after |
| --- | --- | --- |
| `t()` / `plural()` / `tParts()` in `options/App.tsx` | **7** | **195** |
| catalogue | 123 keys | **305 keys** |

For comparison, `onboarding/App.tsx` makes 71 calls and carries no hardcoded copy; `popup/App.tsx` makes 26 and carries none. `options/App.tsx` is 2477 lines and made seven.

**Why it drifted this far unnoticed.** The dead-string test only checks one direction: every `en` key must be used somewhere in source. Nothing checks the reverse, that a string in source went through a key. `react/jsx-no-literals` is the standard guard if we want one; not in this PR.

## Two commits

**81a27b9** — the shell and the Storage tab, 43 keys. The secret field, the shared WebDAV credentials, the save bar and its validation errors, the snapshot status messages, the nav strip, the first-run setup card.

**aa86563** — the rest, 182 keys. Data Types, Device, Activity and Advanced, plus the Encryption section.

## Structural cases, rather than one string each

- **`plural()` for the six counted messages**: files deleted by Forget, files a Forget would delete, bookmarks in a restore point, bookmarks imported, log entries. Substitutions are positional, so the `_one` form can leave `$COUNT$` out where English wants "the one file" rather than "the 1 file".
- **`tParts()` for the three sentences with an element inside them**: the bold "unencrypted" in both encryption warnings, and the two password-manager links, where the *pair* is one placeholder joined by `opt_or`. Splitting those into separate keys would have hard-coded English word order around the emphasis.
- **The `http://` warning** had two inline `<code>` elements in one sentence, and `tParts` carries a single placeholder, so it is two sentences now, each split around its own scheme.
- **`NAV` and the conflict-strategy table** hold `labelKey`/`descKey` rather than text: both are built at module scope, so a `t()` call there would resolve once, before render, and never re-translate.

Reused instead of duplicated: `common_hide`, `common_show`, `common_e2ee`, `common_generate_key`, `popup_restore`, `onb_connecting`, `onb_sign_in_google`, `onb_verifying`, `onb_pass_too_short`, `onb_pass_mismatch`.

## Two judgment calls worth a look

**`IMPORT_FOLDER_NAME` is a constant, not a key.** "Konode Import" is a bookmark folder that travels to every other device through the sync. Translating it would give each language a different folder and break the one thing the sync exists for. It was also written twice before, in the create call and in the message reporting it; now the folder created and the folder claimed cannot drift.

**One copy fix, since the string was being rewritten anyway.** "Chrome extensions cannot access the native password store" is wrong on the Firefox build, which is half of what we ship. It reads "Browser extensions" now. The fact is a browser security boundary, not a Chromium one.

## Deliberately still English

Brand names, the `••••` mask, and the format examples (`ghp_xxx`, `username/repo-name`, `main`, the two server URLs). None of those are language. Verified that nothing else is left: a scan for JSX text, attributes and expression literals returns only those.

## Translations

`hu` and `de` are in `SHIPPED`, so the completeness test requires them for every new key — all 182 land in three languages at once or CI goes red.

**Both are mine and want a reading, German especially.** Terminology follows what the catalogue already uses (Lesezeichen, Erweiterungen, Speicher, Passphrase) and the register stays du/dein, but a native pass over 182 new strings is worth doing before 1.3.0 calls itself the translation release. Corrections belong in Weblate, not here.

`es`, `it`, `zh_Hans` and `et` are not shipped, so they fall back to English per message on the new keys until Weblate catches up. Worth noting what this does to their numbers: `es` and `zh_Hans` were 123/123 an hour ago and are now roughly 40%. That is the cost of doing the extraction, and it is the reason to do it **before** asking anyone to finish a language rather than after.

## Checks

`npm run check` green: 459 tests, 32 files, type-check and lint clean. `npm run build` compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
