### PR TITLE
fix(bookmarks): a way out of a blocked mass deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ All notable changes to Konode. Format loosely follows
 
 ### Fixed
 
+- **A blocked deletion you had no way to allow.** Konode refuses a sync that would remove
+  more than 60% of your bookmarks at once, saves a restore point, and tells you about it.
+  What it never did was give you a way to say yes. The advice was to raise **Max bulk
+  delete from a peer**, but that setting stops at 95%, so a device asking to clear nearly
+  all of its bookmarks stayed blocked at every position of the slider, and the warning
+  never went away. **Settings → Activity** now shows what is being held back, which device
+  asked for it, and how much of your tree it is, with a button that applies it. Saying yes
+  covers that one deletion and nothing after it, and the restore point is already saved
+  before you are asked. Reported by @klausbreyer.
+- **The activity log said bookmarks had been deleted when they had not.** A blocked
+  deletion was logged as "Merged +0 / -48" directly above the warning explaining that
+  those 48 had been refused. It was counting what the other device asked for rather than
+  what was removed, which was nothing. It now reports what it actually applied.
+- **A blocked deletion filled the activity log.** The guard re-checks the same deletion on
+  every sync, so it wrote the same two lines every minute for as long as the situation
+  lasted, pushing everything else out of a 200-entry log. The warning is now written once
+  per incident, the same way restore points have been saved once per incident since 1.3.0.
 - **"Check your username and password", when the password was never the problem.** Some
   servers don't accept a username and password over WebDAV at all. ownCloud Infinite Scale
   is the one that came up: it arrives with HTTP Basic switched off and authenticates through

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -17,9 +17,23 @@ tabs and the extension list have no instant path at all: they travel on that sam
 **Bookmarks I deleted came back / a big cleanup didn't propagate.**
 Konode has a safety cap: a single sync won't apply peer deletions that would remove
 more than a threshold of your local bookmarks (default **60%**), to guard against a
-corrupt deletion log wiping your tree. If you intentionally deleted a large share, raise
-**Max bulk delete from a peer** under **Settings → Device → Safety** (50-95%) and sync
-again. A blocked deletion also saves a restore point, so nothing is lost either way.
+corrupt deletion log wiping your tree. The device receiving the deletion saves a restore
+point and shows "an unusual deletion was blocked", so nothing is lost either way.
+
+**To let the deletion through**, open **Settings → Activity** on the device showing the
+warning and use **Apply the deletion** on the card at the top. It names the device that
+is asking and how many bookmarks are involved, and the restore point is already saved
+before you decide.
+
+**To keep the bookmarks instead**, undo the deletion on the device that made it: open
+**Settings → Activity** there and restore a point from before the cleanup. That puts the
+bookmarks back and clears the deletion record, so it stops being sent to your other
+devices.
+
+Raising **Max bulk delete from a peer** under **Settings → Device → Safety** (50-95%)
+also lets a large cleanup through, but only up to 95% of your tree, so it cannot help
+when a device asks to clear nearly everything. It is a standing setting rather than a
+one-time approval, so prefer the card above.
 
 **Nothing syncs unless I keep a DevTools window open (dev builds).**
 After rebuilding an unpacked extension you must click **↻ reload** on it

--- a/public/_locales/de/messages.json
+++ b/public/_locales/de/messages.json
@@ -60,7 +60,7 @@
     "message": "Konode war nicht erreichbar. Zum erneuten Versuch klicken."
   },
   "popup_recovery_notice": {
-    "message": "Ein ungewöhnlicher Löschvorgang ($COUNT$ Lesezeichen) wurde verhindert und ein Wiederherstellungspunkt gespeichert. Nachzulesen unter Einstellungen → Aktivität.",
+    "message": "Ein ungewöhnlicher Löschvorgang ($COUNT$ Lesezeichen) wurde verhindert und ein Wiederherstellungspunkt gespeichert. Übernimm ihn oder behalte sie unter Einstellungen → Aktivität.",
     "placeholders": {
       "count": {
         "content": "$1",
@@ -912,6 +912,80 @@
   },
   "opt_cancel": {
     "message": "Abbrechen"
+  },
+  "opt_blocked_section": {
+    "message": "Verhinderter Löschvorgang"
+  },
+  "opt_blocked_section_sub": {
+    "message": "Ein anderes Gerät wollte ungewöhnlich viele deiner Lesezeichen entfernen, deshalb hat Konode das zurückgehalten. Übernimm es, wenn es so gewollt war, oder behalte sie."
+  },
+  "opt_blocked_headline_one": {
+    "message": "$COUNT$ von deinen $TOTAL$ Lesezeichen",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "1"
+      },
+      "total": {
+        "content": "$2",
+        "example": "49"
+      }
+    }
+  },
+  "opt_blocked_headline_other": {
+    "message": "$COUNT$ von deinen $TOTAL$ Lesezeichen",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "48"
+      },
+      "total": {
+        "content": "$2",
+        "example": "49"
+      }
+    }
+  },
+  "opt_blocked_count_one": {
+    "message": "$COUNT$ Lesezeichen",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "1"
+      }
+    }
+  },
+  "opt_blocked_count_other": {
+    "message": "$COUNT$ Lesezeichen",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "48"
+      }
+    }
+  },
+  "opt_blocked_from": {
+    "message": "Angefordert von $DEVICE$.",
+    "placeholders": {
+      "device": {
+        "content": "$1",
+        "example": "boxbox"
+      }
+    }
+  },
+  "opt_blocked_from_unknown": {
+    "message": "Von einem anderen Gerät angefordert."
+  },
+  "opt_blocked_saved": {
+    "message": "Es wurde nichts entfernt, und vorher wurde ein Wiederherstellungspunkt gespeichert."
+  },
+  "opt_blocked_apply": {
+    "message": "Löschvorgang übernehmen"
+  },
+  "opt_blocked_confirm_apply": {
+    "message": "Übernehmen und löschen"
+  },
+  "opt_blocked_keep": {
+    "message": "Wenn du sie lieber behalten möchtest, stelle auf dem anfordernden Gerät einen Punkt von vor dem Aufräumen wieder her. Damit verschwindet dort der Löschvermerk, und er wird nicht mehr hierher geschickt."
   },
   "opt_snapshots_section": {
     "message": "Wiederherstellungspunkte"

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -80,8 +80,8 @@
     "description": "The popup could not read its own state. The whole banner is a button, hence 'tap to retry'."
   },
   "popup_recovery_notice": {
-    "message": "An unusual deletion ($COUNT$ bookmarks) was blocked and a restore point was saved. Review in Settings → Activity.",
-    "description": "The mass-delete guard refused a peer's deletions. Reassuring by design: nothing was lost. 'Settings → Activity' names a tab, so it must match the tab's own translation.",
+    "message": "An unusual deletion ($COUNT$ bookmarks) was blocked and a restore point was saved. Apply it or keep them in Settings → Activity.",
+    "description": "The mass-delete guard refused a peer's deletions. Reassuring by design: nothing was lost. Said 'Review in' until there was something to decide there; now the banner leads to a real choice, so it names it. 'Settings → Activity' names a tab, so it must match the tab's own translation.",
     "placeholders": {
       "count": {
         "content": "$1",
@@ -1026,6 +1026,65 @@
   },
   "opt_cancel": {
     "message": "Cancel"
+  },
+  "opt_blocked_section": {
+    "message": "Blocked deletion",
+    "description": "Card in Settings → Activity, shown only while the mass-delete guard is holding a peer's deletion back. This is where the popup banner sends people."
+  },
+  "opt_blocked_section_sub": {
+    "message": "Another device asked to remove an unusual number of your bookmarks, so Konode held it back. Apply it if you meant to, or keep them.",
+    "description": "Sub-heading under 'Blocked deletion'. Says what happened and that there is a choice to make."
+  },
+  "opt_blocked_headline_one": {
+    "message": "$COUNT$ of your $TOTAL$ bookmarks",
+    "description": "How big the blocked deletion is. The proportion is the whole point, so both numbers stay in the sentence.",
+    "placeholders": {
+      "count": { "content": "$1", "example": "1" },
+      "total": { "content": "$2", "example": "49" }
+    }
+  },
+  "opt_blocked_headline_other": {
+    "message": "$COUNT$ of your $TOTAL$ bookmarks",
+    "description": "Plural of opt_blocked_headline_one.",
+    "placeholders": {
+      "count": { "content": "$1", "example": "48" },
+      "total": { "content": "$2", "example": "49" }
+    }
+  },
+  "opt_blocked_count_one": {
+    "message": "$COUNT$ bookmark",
+    "description": "Fallback headline for a notice saved by an older version, which recorded the count but not the size of the tree.",
+    "placeholders": { "count": { "content": "$1", "example": "1" } }
+  },
+  "opt_blocked_count_other": {
+    "message": "$COUNT$ bookmarks",
+    "description": "Plural of opt_blocked_count_one.",
+    "placeholders": { "count": { "content": "$1", "example": "48" } }
+  },
+  "opt_blocked_from": {
+    "message": "Asked for by $DEVICE$.",
+    "description": "Names the peer device that sent the deletion. $DEVICE$ is a name the user chose.",
+    "placeholders": { "device": { "content": "$1", "example": "boxbox" } }
+  },
+  "opt_blocked_from_unknown": {
+    "message": "Asked for by another device.",
+    "description": "Used when the peer's packet carries no device name (older builds did not send one)."
+  },
+  "opt_blocked_saved": {
+    "message": "Nothing was removed, and a restore point was saved first.",
+    "description": "The reassurance. Sits right after opt_blocked_from in the same paragraph."
+  },
+  "opt_blocked_apply": {
+    "message": "Apply the deletion",
+    "description": "Button. First step of two, because applying removes bookmarks."
+  },
+  "opt_blocked_confirm_apply": {
+    "message": "Apply and delete",
+    "description": "The confirming second click. Deliberately says the word delete."
+  },
+  "opt_blocked_keep": {
+    "message": "To keep them instead, restore a point from before the cleanup on the device that asked. That clears its record of the deletion, so it stops being sent here.",
+    "description": "The other way out, which has to happen on the OTHER device. Worth stating because there is nothing on this device that can stop the asking."
   },
   "opt_snapshots_section": {
     "message": "Restore points"

--- a/public/_locales/es/messages.json
+++ b/public/_locales/es/messages.json
@@ -57,7 +57,7 @@
     "message": "No se pudo contactar a Konode. Toca para reintentar."
   },
   "popup_recovery_notice": {
-    "message": "Se bloqueó una eliminación inusual ($COUNT$ marcadores) y se guardó un punto de restauración. Revísalo en Configuración → Actividad.",
+    "message": "Se bloqueó una eliminación inusual ($COUNT$ marcadores) y se guardó un punto de restauración. Aplícala o consérvalos en Configuración → Actividad.",
     "placeholders": {
       "count": {
         "content": "$1",
@@ -841,6 +841,80 @@
   },
   "opt_cancel": {
     "message": "Cancelar"
+  },
+  "opt_blocked_section": {
+    "message": "Eliminación bloqueada"
+  },
+  "opt_blocked_section_sub": {
+    "message": "Otro dispositivo pidió quitar un número inusual de tus marcadores, así que Konode lo retuvo. Aplícalo si era lo que querías, o consérvalos."
+  },
+  "opt_blocked_headline_one": {
+    "message": "$COUNT$ de tus $TOTAL$ marcadores",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "1"
+      },
+      "total": {
+        "content": "$2",
+        "example": "49"
+      }
+    }
+  },
+  "opt_blocked_headline_other": {
+    "message": "$COUNT$ de tus $TOTAL$ marcadores",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "48"
+      },
+      "total": {
+        "content": "$2",
+        "example": "49"
+      }
+    }
+  },
+  "opt_blocked_count_one": {
+    "message": "$COUNT$ marcador",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "1"
+      }
+    }
+  },
+  "opt_blocked_count_other": {
+    "message": "$COUNT$ marcadores",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "48"
+      }
+    }
+  },
+  "opt_blocked_from": {
+    "message": "Lo pidió $DEVICE$.",
+    "placeholders": {
+      "device": {
+        "content": "$1",
+        "example": "boxbox"
+      }
+    }
+  },
+  "opt_blocked_from_unknown": {
+    "message": "Lo pidió otro dispositivo."
+  },
+  "opt_blocked_saved": {
+    "message": "No se quitó nada, y antes se guardó un punto de restauración."
+  },
+  "opt_blocked_apply": {
+    "message": "Aplicar la eliminación"
+  },
+  "opt_blocked_confirm_apply": {
+    "message": "Aplicar y eliminar"
+  },
+  "opt_blocked_keep": {
+    "message": "Si prefieres conservarlos, restaura en el dispositivo que lo pidió un punto anterior a la limpieza. Eso borra allí el registro de la eliminación, para que deje de enviarse aquí."
   },
   "opt_snapshots_section": {
     "message": "Puntos de restauración"

--- a/public/_locales/hu/messages.json
+++ b/public/_locales/hu/messages.json
@@ -60,7 +60,7 @@
     "message": "A Konode nem érhető el. Kattints az újrapróbálkozáshoz."
   },
   "popup_recovery_notice": {
-    "message": "Egy szokatlan törlést ($COUNT$ könyvjelző) letiltottunk, és mentettünk egy visszaállítási pontot. Megtekintés: Beállítások → Tevékenység.",
+    "message": "Egy szokatlan törlést ($COUNT$ könyvjelző) letiltottunk, és mentettünk egy visszaállítási pontot. Alkalmazd vagy tartsd meg őket: Beállítások → Aktivitás.",
     "placeholders": {
       "count": {
         "content": "$1",
@@ -912,6 +912,80 @@
   },
   "opt_cancel": {
     "message": "Mégse"
+  },
+  "opt_blocked_section": {
+    "message": "Letiltott törlés"
+  },
+  "opt_blocked_section_sub": {
+    "message": "Egy másik eszköz szokatlanul sok könyvjelződ törlését kérte, ezért a Konode visszatartotta. Alkalmazd, ha szándékos volt, vagy tartsd meg őket."
+  },
+  "opt_blocked_headline_one": {
+    "message": "$COUNT$ könyvjelző a $TOTAL$ közül",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "1"
+      },
+      "total": {
+        "content": "$2",
+        "example": "49"
+      }
+    }
+  },
+  "opt_blocked_headline_other": {
+    "message": "$COUNT$ könyvjelző a $TOTAL$ közül",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "48"
+      },
+      "total": {
+        "content": "$2",
+        "example": "49"
+      }
+    }
+  },
+  "opt_blocked_count_one": {
+    "message": "$COUNT$ könyvjelző",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "1"
+      }
+    }
+  },
+  "opt_blocked_count_other": {
+    "message": "$COUNT$ könyvjelző",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "48"
+      }
+    }
+  },
+  "opt_blocked_from": {
+    "message": "$DEVICE$ kérte.",
+    "placeholders": {
+      "device": {
+        "content": "$1",
+        "example": "boxbox"
+      }
+    }
+  },
+  "opt_blocked_from_unknown": {
+    "message": "Egy másik eszköz kérte."
+  },
+  "opt_blocked_saved": {
+    "message": "Semmi nem lett törölve, és előtte mentettünk egy visszaállítási pontot."
+  },
+  "opt_blocked_apply": {
+    "message": "Törlés alkalmazása"
+  },
+  "opt_blocked_confirm_apply": {
+    "message": "Alkalmazás és törlés"
+  },
+  "opt_blocked_keep": {
+    "message": "Ha inkább megtartanád őket, állíts vissza egy takarítás előtti pontot azon az eszközön, amelyik kérte. Ezzel ott törlődik a törlés nyoma, így nem küldi tovább ide."
   },
   "opt_snapshots_section": {
     "message": "Visszaállítási pontok"

--- a/public/_locales/zh_CN/messages.json
+++ b/public/_locales/zh_CN/messages.json
@@ -57,7 +57,7 @@
     "message": "无法连接 Konode。点击重试。"
   },
   "popup_recovery_notice": {
-    "message": "一次异常删除（$COUNT$ 条书签）被阻止，已保存恢复点。请在设置 → 活动中查看。",
+    "message": "一次异常删除（$COUNT$ 条书签）被阻止，已保存恢复点。请在设置 → 活动中应用或保留。",
     "placeholders": {
       "count": {
         "content": "$1",
@@ -903,6 +903,80 @@
   },
   "opt_cancel": {
     "message": "取消"
+  },
+  "opt_blocked_section": {
+    "message": "已阻止的删除"
+  },
+  "opt_blocked_section_sub": {
+    "message": "另一台设备请求删除异常数量的书签，因此 Konode 将其拦截。如果这是你的本意，可以应用；否则保留它们。"
+  },
+  "opt_blocked_headline_one": {
+    "message": "$TOTAL$ 条书签中的 $COUNT$ 条",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "1"
+      },
+      "total": {
+        "content": "$2",
+        "example": "49"
+      }
+    }
+  },
+  "opt_blocked_headline_other": {
+    "message": "$TOTAL$ 条书签中的 $COUNT$ 条",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "48"
+      },
+      "total": {
+        "content": "$2",
+        "example": "49"
+      }
+    }
+  },
+  "opt_blocked_count_one": {
+    "message": "$COUNT$ 条书签",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "1"
+      }
+    }
+  },
+  "opt_blocked_count_other": {
+    "message": "$COUNT$ 条书签",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "48"
+      }
+    }
+  },
+  "opt_blocked_from": {
+    "message": "由 $DEVICE$ 请求。",
+    "placeholders": {
+      "device": {
+        "content": "$1",
+        "example": "boxbox"
+      }
+    }
+  },
+  "opt_blocked_from_unknown": {
+    "message": "由另一台设备请求。"
+  },
+  "opt_blocked_saved": {
+    "message": "没有删除任何内容，并已事先保存恢复点。"
+  },
+  "opt_blocked_apply": {
+    "message": "应用此删除"
+  },
+  "opt_blocked_confirm_apply": {
+    "message": "应用并删除"
+  },
+  "opt_blocked_keep": {
+    "message": "如果想保留它们，请在发出请求的设备上还原到清理之前的恢复点。这会清除该设备上的删除记录，它就不会再发送到这里。"
   },
   "opt_snapshots_section": {
     "message": "还原点"

--- a/src/background/service-worker.ts
+++ b/src/background/service-worker.ts
@@ -2,7 +2,7 @@
 // Handles: alarm-based polling, bookmark/tab listeners, message routing
 
 import type { ExtensionMessage, ExtensionResponse, SyncState } from "@/lib/types";
-import { getSettings, getState, setState, saveSettings, clearStaleSyncLock, KEYS } from "@/lib/utils/storage";
+import { getSettings, getState, setState, saveSettings, clearStaleSyncLock, setBulkDeleteApproval, KEYS } from "@/lib/utils/storage";
 import { SyncEngine } from "@/lib/sync/sync-engine";
 import { registerBookmarkListeners } from "@/lib/handlers/bookmarks-handler";
 import { createBackend } from "@/lib/backends/abstract-backend";
@@ -245,6 +245,29 @@ async function handleMessage(message: ExtensionMessage): Promise<ExtensionRespon
       if (!syncEngine) return { type: "ERROR", payload: "Engine not initialized" };
       const removed = await syncEngine.forgetDevice(message.payload.device_id);
       return { type: "DEVICE_FORGOTTEN", payload: { removed } };
+    }
+
+    case "APPROVE_BULK_DELETE": {
+      if (!syncEngine) return { type: "ERROR", payload: "Engine not initialized" };
+      // Arm the latch, then sync immediately. The approval is consumed by the next
+      // bookmark merge, and making the user wait out the sync interval to see anything
+      // happen would read as a dead button. Bookmarks only: nothing else is involved.
+      const pending = message.payload?.blocked ?? 0;
+      if (!Number.isFinite(pending) || pending <= 0) {
+        return { type: "ERROR", payload: "There is no blocked deletion to apply." };
+      }
+      await setBulkDeleteApproval(pending);
+      const outcome = await syncEngine.sync(["bookmarks"]);
+      if (outcome === "no-backend") {
+        await setBulkDeleteApproval(0);
+        return { type: "ERROR", payload: "No storage backend is set up yet." };
+      }
+      // A sync already running will consume the latch on this cycle or the next one, so
+      // the approval stands rather than being thrown away with the error.
+      if (outcome === "already-running") {
+        return { type: "ERROR", payload: "A sync is already running. The deletion will be applied on this cycle." };
+      }
+      return { type: "OK" };
     }
 
     case "LIST_SNAPSHOTS": {

--- a/src/lib/handlers/bookmarks-handler.ts
+++ b/src/lib/handlers/bookmarks-handler.ts
@@ -10,6 +10,7 @@ import {
   getFolderMoves, setFolderMoves, updateFolderMoves,
   getTitles, setTitles, updateTitles,
   getFolderRenames, setFolderRenames, updateFolderRenames,
+  getBulkDeleteApproval, setBulkDeleteApproval,
 } from "@/lib/utils/storage";
 import { defaultOtherRootId, matchLocalRoot, matchLocalRootEx, rootKind } from "@/lib/utils/bookmark-roots";
 import { canonicalUrlKey } from "@/lib/utils/url";
@@ -381,14 +382,32 @@ export function normalizePayload(payload: unknown): BookmarkPayload {
 
 // ─── Write (import from remote) ──────────────────────────────────────────
 
+/**
+ * What the mass-delete guard refused, and the arithmetic behind it.
+ *
+ * The count alone was not enough to act on: the popup could say "48 bookmarks" but not
+ * what it was 48 *of*, and the user has to know that before deciding whether to wave it
+ * through. Carrying the cap and the local total means the notice can say "48 of your 49",
+ * and it saves the sync engine recomputing numbers the merge already had in hand.
+ */
+export interface BulkDeleteBlock {
+  /** Local bookmarks the guard refused to remove this merge. */
+  blocked: number;
+  /** The ceiling it exceeded. */
+  cap: number;
+  /** URL bookmarks present locally when the merge ran. */
+  localTotal: number;
+  /** The configured percentage the cap came from. */
+  pct: number;
+}
+
 export async function importBookmarks(
   payload: unknown,
   strategy: "merge" | "replace" = "merge",
   conflictStrategy: ConflictStrategy = "lww",
   deletePercent = 60,
-  // Called when the mass-delete guard blocks a peer's deletions (recovery signal) —
-  // `blocked` is how many local bookmarks the guard refused to remove this merge.
-  onBulkBlocked?: (blocked: number) => void
+  // Called when the mass-delete guard blocks a peer's deletions (recovery signal).
+  onBulkBlocked?: (info: BulkDeleteBlock) => void
 ): Promise<void> {
   assertDataTypeApi("bookmarks");
   const {
@@ -522,7 +541,7 @@ async function mergeBookmarks(
   logs: MergeLogs,
   strategy: ConflictStrategy,
   deletePercent = 60,
-  onBulkBlocked?: (blocked: number) => void,
+  onBulkBlocked?: (info: BulkDeleteBlock) => void,
 ): Promise<void> {
   // All URL identity maps below are keyed by the CANONICAL url (canonicalUrlKey),
   // not the raw string, so a bare-origin bookmark that Chromium/Firefox store with
@@ -574,17 +593,43 @@ async function mergeBookmarks(
     }
   }
   // Safety: refuse a mass-delete from a corrupt/oversized tombstone log. The
-  // threshold is user-configurable (Settings → Advanced, default 60%): a floor of
-  // 20 keeps small trees from tripping it, and a normal bulk cleanup up to the
+  // threshold is user-configurable (Settings → Device → Safety, default 60%): a floor
+  // of 20 keeps small trees from tripping it, and a normal bulk cleanup up to the
   // percentage still propagates.
+  //
+  // The percentage alone cannot answer every case, which is why the approval latch
+  // exists: the slider stops at 95%, so a peer clearing nearly its whole tree was
+  // blocked at every setting and the warning never cleared (#18). Reading the latch is
+  // gated on being over the cap so the ordinary merge does not pay for a storage read
+  // it will not use, and consuming it clears it — one incident, not a new threshold.
   const pct = deletePercent > 0 ? deletePercent : 60;
   const cap = Math.max(20, Math.floor((localFlat.length * pct) / 100));
-  if (toRemove.length > cap) {
-    logger.warn("mergeBookmarks", `Skipped deleting ${toRemove.length} bookmarks (cap ${cap}, ${pct}% of ${localFlat.length}): exceeds the mass-delete guard`);
-    onBulkBlocked?.(toRemove.length);
+  const overCap = toRemove.length > cap;
+  const approvedFor = overCap ? await getBulkDeleteApproval() : 0;
+  // Honoured only for a deletion no larger than the one the user actually saw. Anything
+  // bigger arrived after they decided, and has not been approved by anyone.
+  const approved = approvedFor > 0 && toRemove.length <= approvedFor;
+  // Spent either way: an approval that no longer matches is stale, not pending, and
+  // leaving it armed would let it cash out against some later deletion instead.
+  if (approvedFor > 0) await setBulkDeleteApproval(0);
+  // What the removal loop ACTUALLY did. The summary below used to report
+  // `toRemove.length`, which is what the peer asked for: a blocked merge logged
+  // "-48" directly above the warning saying those 48 were refused (#19). It also
+  // counts a remove() that threw, which the old number quietly included.
+  let removed = 0;
+  if (overCap && !approved) {
+    // Console only, on every cycle. The RETAINED warning is written once per incident
+    // by the sync engine (recordBlockedDeletion), because the guard re-evaluates the
+    // same peer deletions every sync: warning from here wrote one identical pair a
+    // minute into the Activity log and evicted the entry the banner points at (#20).
+    logger.info("mergeBookmarks", `Skipped deleting ${toRemove.length} bookmarks (cap ${cap}, ${pct}% of ${localFlat.length}): exceeds the mass-delete guard`);
+    onBulkBlocked?.({ blocked: toRemove.length, cap, localTotal: localFlat.length, pct });
   } else {
     for (const id of toRemove) {
-      try { await browser.bookmarks.remove(id); } catch (err) { logger.error("Bookmark delete (tombstone)", err); }
+      try { await browser.bookmarks.remove(id); removed++; } catch (err) { logger.error("Bookmark delete (tombstone)", err); }
+    }
+    if (approved) {
+      logger.event("mergeBookmarks", `Applied ${removed} bookmark deletions you approved (over the ${pct}% guard).`);
     }
   }
 
@@ -875,8 +920,8 @@ async function mergeBookmarks(
   // The most informative line about what a sync actually DID to the tree, so it belongs
   // in the user's Activity log — but only when it changed something. Every idle cycle
   // logging "+0 / -0 / moved 0" is exactly the noise that used to evict the warnings.
-  const summary = `Merged +${added} / -${toRemove.length} / moved ${moved} / renamed ${renamed}+${renamedFolders} / folders ${folderMoved} / shells ${shells} (folders preserved)`;
-  if (added || toRemove.length || moved || renamed || renamedFolders || folderMoved || shells) logger.event("mergeBookmarks", summary);
+  const summary = `Merged +${added} / -${removed} / moved ${moved} / renamed ${renamed}+${renamedFolders} / folders ${folderMoved} / shells ${shells} (folders preserved)`;
+  if (added || removed || moved || renamed || renamedFolders || folderMoved || shells) logger.event("mergeBookmarks", summary);
   else logger.info("mergeBookmarks", summary);
 }
 

--- a/src/lib/handlers/bookmarks-merge.test.ts
+++ b/src/lib/handlers/bookmarks-merge.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { importBookmarks, exportBookmarkPayload, registerBookmarkListeners } from "@/lib/handlers/bookmarks-handler";
-import { getTombstones, setTombstones } from "@/lib/utils/storage";
+import { getTombstones, setTombstones, getBulkDeleteApproval, setBulkDeleteApproval, KEYS } from "@/lib/utils/storage";
 import type { BookmarkPayload, SyncBookmark } from "@/lib/types";
 
 // These exercise the real merge/replace logic against the in-memory
@@ -266,6 +266,50 @@ describe("importBookmarks — mass-delete guard (configurable percent)", () => {
     // Same 70% delete, but deletePercent=80 → cap 80 → 70 ≤ 80 → deletions apply.
     await importBookmarks(payload([], tombstonesFor(70)), "merge", "lww", 80);
     expect((await localUrls()).length).toBe(30);
+  });
+
+  /** The merge summary line from the Activity log, or undefined if none was kept. */
+  async function summaryLine(): Promise<string | undefined> {
+    await new Promise((r) => setTimeout(r, 0)); // logger fires appendAudit unawaited
+    const entries = ((await chrome.storage.local.get(KEYS.AUDIT_LOG))[KEYS.AUDIT_LOG] ?? []) as
+      { detail?: string }[];
+    return entries.map((e) => e.detail).reverse().find((d) => d?.startsWith("Merged "));
+  }
+
+  it("reports the deletions it APPLIED, not the ones the peer asked for", async () => {
+    await seedMany(100);
+    await importBookmarks(payload([], tombstonesFor(70)), "merge", "lww");
+
+    // Nothing was removed, so the summary must not claim 70 were. It used to print
+    // `-70` directly above the warning saying those 70 had been refused.
+    expect((await localUrls()).length).toBe(100);
+    const line = await summaryLine();
+    if (line) expect(line).toContain("-0");
+  });
+
+  it("applies a blocked deletion the user approved, and spends the approval", async () => {
+    await seedMany(100);
+    // The slider cannot reach this: 95% of 100 is a cap of 95, and 98 is over it.
+    await importBookmarks(payload([], tombstonesFor(98)), "merge", "lww", 95);
+    expect((await localUrls()).length).toBe(100);
+
+    await setBulkDeleteApproval(98);
+    await importBookmarks(payload([], tombstonesFor(98)), "merge", "lww", 95);
+    expect((await localUrls()).length).toBe(2);
+    // One incident, not a new threshold: the latch is empty again afterwards.
+    expect(await getBulkDeleteApproval()).toBe(0);
+  });
+
+  it("refuses to spend an approval on a deletion bigger than the one approved", async () => {
+    await seedMany(100);
+    // The user saw and approved 70. What turned up is 98, which nobody approved.
+    await setBulkDeleteApproval(70);
+    await importBookmarks(payload([], tombstonesFor(98)), "merge", "lww", 95);
+
+    expect((await localUrls()).length).toBe(100);
+    // Still spent, though: it belonged to an incident that no longer matches, and
+    // leaving it armed would let it cash out against something later instead.
+    expect(await getBulkDeleteApproval()).toBe(0);
   });
 });
 

--- a/src/lib/sync/sync-engine.test.ts
+++ b/src/lib/sync/sync-engine.test.ts
@@ -60,13 +60,25 @@ type EnginePrivate = {
   syncAllTypes(types: DataType[], backend: IBackend, state: SyncState): Promise<string[]>;
   buildPacket(dataType: DataType, payload: unknown): Promise<SyncPacket>;
   recordBlockedDeletion(
-    blocked: number,
+    blocked: BlockedArg,
     syncedBookmarks: boolean
   ): Promise<SyncState["recovery_notice"]>;
   encryptionWarnings: Map<string, string>;
 };
 function priv(engine: SyncEngine): EnginePrivate {
   return engine as unknown as EnginePrivate;
+}
+
+/** What the merge hands the engine when the guard blocks, or null when it didn't. */
+type BlockedArg =
+  | { blocked: number; cap: number; localTotal: number; pct: number; device_id?: string; device_label?: string | null }
+  | null;
+
+/** A blocked deletion of `n`, with the arithmetic a 60% guard on a 100-bookmark tree
+ *  would actually have produced. The numbers past `blocked` only ride along to the
+ *  notice, so the tests that care about latching pass the same plausible set every time. */
+function block(n: number, device_label: string | null = "peer-1"): BlockedArg {
+  return { blocked: n, cap: 60, localTotal: 100, pct: 60, device_id: "peer", device_label };
 }
 
 function makeEngine(): SyncEngine {
@@ -625,9 +637,9 @@ describe("SyncEngine — blocked mass-delete takes ONE restore point per inciden
   it("writes ONE restore point even though the deletion is blocked every sync", async () => {
     const { engine, taken } = countingEngine();
 
-    const first = await priv(engine).recordBlockedDeletion(50, true);
-    const second = await priv(engine).recordBlockedDeletion(50, true);
-    const third = await priv(engine).recordBlockedDeletion(50, true);
+    const first = await priv(engine).recordBlockedDeletion(block(50), true);
+    const second = await priv(engine).recordBlockedDeletion(block(50), true);
+    const third = await priv(engine).recordBlockedDeletion(block(50), true);
 
     expect(taken()).toBe(1);
     // ...but the banner keeps being surfaced while the situation persists.
@@ -637,40 +649,60 @@ describe("SyncEngine — blocked mass-delete takes ONE restore point per inciden
   it("earns a new restore point after a clean bookmark sync ends the incident", async () => {
     const { engine, taken } = countingEngine();
 
-    await priv(engine).recordBlockedDeletion(50, true);
+    await priv(engine).recordBlockedDeletion(block(50), true);
     expect(taken()).toBe(1);
 
     // A sync that merged bookmarks and blocked nothing → incident over.
-    expect(await priv(engine).recordBlockedDeletion(0, true)).toBeNull();
+    expect(await priv(engine).recordBlockedDeletion(null, true)).toBeNull();
 
     // A later block is a NEW incident and deserves its own restore point.
-    await priv(engine).recordBlockedDeletion(30, true);
+    await priv(engine).recordBlockedDeletion(block(30), true);
     expect(taken()).toBe(2);
   });
 
   it("a sync that never merged bookmarks does NOT end the incident", async () => {
     const { engine, taken } = countingEngine();
 
-    await priv(engine).recordBlockedDeletion(50, true);
-    await priv(engine).recordBlockedDeletion(0, false); // e.g. sync(["history"])
-    await priv(engine).recordBlockedDeletion(50, true);
+    await priv(engine).recordBlockedDeletion(block(50), true);
+    await priv(engine).recordBlockedDeletion(null, false); // e.g. sync(["history"])
+    await priv(engine).recordBlockedDeletion(block(50), true);
 
     expect(taken()).toBe(1);
+  });
+
+  it("writes ONE Activity-log warning per incident, not one per sync", async () => {
+    const { engine } = countingEngine();
+
+    await priv(engine).recordBlockedDeletion(block(50), true);
+    await priv(engine).recordBlockedDeletion(block(50), true);
+    await priv(engine).recordBlockedDeletion(block(50), true);
+    // logger.warn fires appendAudit without awaiting; let the serialized write land.
+    await new Promise((r) => setTimeout(r, 0));
+
+    const entries = ((await chrome.storage.local.get(KEYS.AUDIT_LOG))[KEYS.AUDIT_LOG] ?? []) as
+      { detail?: string }[];
+    const blocked = entries.filter((e) => e.detail?.includes("Blocked a deletion"));
+    // Three blocked syncs, one entry. The guard re-evaluates the same peer deletions
+    // every cycle, and warning each time buried the entry the popup banner points at.
+    expect(blocked).toHaveLength(1);
+    // And it says enough to act on: the proportion, and who asked.
+    expect(blocked[0].detail).toContain("50 of your 100 bookmarks");
+    expect(blocked[0].detail).toContain("peer-1");
   });
 
   it("retries on the next sync when the restore-point write fails", async () => {
     const { engine, taken } = countingEngine(1); // first snapshotNow() rejects
 
     // A failed write must not throw out, and must not latch the incident closed.
-    await expect(priv(engine).recordBlockedDeletion(50, true)).resolves.toMatchObject({ blocked: 50 });
+    await expect(priv(engine).recordBlockedDeletion(block(50), true)).resolves.toMatchObject({ blocked: 50 });
     expect(taken()).toBe(1);
 
     // Next cycle tries again — and this time succeeds.
-    await priv(engine).recordBlockedDeletion(50, true);
+    await priv(engine).recordBlockedDeletion(block(50), true);
     expect(taken()).toBe(2);
 
     // Now it IS latched, so no third attempt.
-    await priv(engine).recordBlockedDeletion(50, true);
+    await priv(engine).recordBlockedDeletion(block(50), true);
     expect(taken()).toBe(2);
   });
 });

--- a/src/lib/sync/sync-engine.ts
+++ b/src/lib/sync/sync-engine.ts
@@ -4,7 +4,7 @@ import type { SyncSettings, SyncState, DataType, SyncPacket, SyncSession, SyncEx
 import { createBackend } from "@/lib/backends/abstract-backend";
 import { normalizeRepoSlug } from "@/lib/backends/github-backend";
 import { createSnapshot as writeSnapshot, listSnapshots as readSnapshots, restoreSnapshot as applySnapshot, deleteSnapshot as dropSnapshot, type SnapshotMeta } from "@/lib/sync/snapshots";
-import { exportBookmarkPayload, importBookmarks } from "@/lib/handlers/bookmarks-handler";
+import { exportBookmarkPayload, importBookmarks, type BulkDeleteBlock } from "@/lib/handlers/bookmarks-handler";
 import { exportSession, importSession } from "@/lib/handlers/tabs-handler";
 import { exportHistory, importHistory } from "@/lib/handlers/history-handler";
 import { exportExtensions } from "@/lib/handlers/extensions-handler";
@@ -126,10 +126,17 @@ export class SyncEngine {
   // even though the local checksum record says this content already went. Rebuilt every
   // sync by `findOwnMissingFiles` and consumed by `uploadIfChanged`.
   private ownFilesMissing = new Set<DataType>();
-  // Local bookmarks the mass-delete guard refused to remove this sync (recovery
-  // signal). >0 → an unusual deletion was blocked; sync() saves an auto-snapshot and
-  // flags state.recovery_notice so the popup can surface it.
-  private bulkBlockedThisSync = 0;
+  // What the mass-delete guard refused this sync, and which peer asked (recovery
+  // signal). Non-null → an unusual deletion was blocked; sync() saves an auto-snapshot
+  // and flags state.recovery_notice so the popup can surface it and Settings → Activity
+  // can offer to apply it.
+  //
+  // `blocked` accumulates across peers, because two devices can each ask on the same
+  // cycle; the rest describes the LAST block, which is the one the numbers belong to.
+  // A single peer is the ordinary case by a wide margin.
+  private bulkBlockedThisSync:
+    | (BulkDeleteBlock & { device_id?: string; device_label?: string | null })
+    | null = null;
 
   constructor(
     private settings: SyncSettings,
@@ -234,7 +241,7 @@ export class SyncEngine {
 
     this.encryptionWarnings.clear();
     this.bytesThisSync = 0;
-    this.bulkBlockedThisSync = 0;
+    this.bulkBlockedThisSync = null;
     const state = await setState({ status: "syncing", last_error: null, recovery_notice: null });
     this.onStateChange(state);
 
@@ -446,26 +453,51 @@ export class SyncEngine {
    * banner keeps showing while the situation persists.
    */
   private async recordBlockedDeletion(
-    blocked: number,
+    blocked: (BulkDeleteBlock & { device_id?: string; device_label?: string | null }) | null,
     syncedBookmarks: boolean
   ): Promise<SyncState["recovery_notice"]> {
-    if (blocked <= 0) {
+    if (!blocked) {
       if (syncedBookmarks && (await getRecoverySnapshotTaken())) {
         await setRecoverySnapshotTaken(false);
       }
       return null;
     }
-    if (!(await getRecoverySnapshotTaken())) {
+    // One read, two decisions. The latch means "this incident is already on the
+    // record", which is true of the restore point and of the Activity-log warning
+    // alike, so they belong behind the same test rather than two drifting ones.
+    const alreadyRecorded = await getRecoverySnapshotTaken();
+    if (!alreadyRecorded) {
+      // THE retained warning for a blocked deletion, written once per incident. The
+      // merge only logs to the console, because it re-evaluates the same peer
+      // deletions on every cycle and writing this from there filled the log with one
+      // identical pair a minute (#20). Naming the peer and the total is what makes it
+      // actionable rather than alarming (#18).
+      const who = blocked.device_label ? ` asked for by ${blocked.device_label}` : "";
+      logger.warn(
+        "mergeBookmarks",
+        `Blocked a deletion of ${blocked.blocked} of your ${blocked.localTotal} bookmarks` +
+          `${who} (cap ${blocked.cap}, ${blocked.pct}% of the tree). Nothing was removed and a ` +
+          "restore point was saved. Apply it or keep them in Settings → Activity."
+      );
       try {
         await this.snapshotNow();
         await setRecoverySnapshotTaken(true);
       } catch (e) {
         // Leave the latch clear so the next cycle retries the write — a failed
-        // snapshot must not count as "this incident is covered".
+        // snapshot must not count as "this incident is covered". The warning above
+        // then repeats on the retry, which is the right trade: a backend that cannot
+        // hold the restore point is worth saying twice, and it is not the steady state.
         logger.warn("SyncEngine", `Recovery snapshot failed: ${e instanceof Error ? e.message : e}`);
       }
     }
-    return { at: new Date().toISOString(), blocked };
+    return {
+      at: new Date().toISOString(),
+      blocked: blocked.blocked,
+      cap: blocked.cap,
+      local_total: blocked.localTotal,
+      device_id: blocked.device_id,
+      device_label: blocked.device_label ?? null,
+    };
   }
 
   // ─── Snapshots (restore points) ───────────────────────────────────────
@@ -1134,6 +1166,9 @@ export class SyncEngine {
     await this.applyPayload(dataType, payload, {
       device_id: packet.device_id,
       timestamp: packet.timestamp,
+      // Outside the encrypted payload, so it reads even with E2EE on. It is what the
+      // recovery notice shows instead of a truncated id when the guard blocks.
+      device_label: packet.device_label ?? null,
     }, isLocalEmpty);
   }
 
@@ -1141,7 +1176,7 @@ export class SyncEngine {
   private async applyPayload(
     dataType: DataType,
     payload: unknown,
-    meta: { device_id: string; timestamp: string },
+    meta: { device_id: string; timestamp: string; device_label?: string | null },
     isLocalEmpty: boolean
   ): Promise<void> {
     // Validate the parsed payload shape before handing untrusted remote data to
@@ -1162,7 +1197,14 @@ export class SyncEngine {
           isLocalEmpty ? "replace" : "merge",
           this.settings.conflict_strategy,
           this.settings.bulk_delete_percent,
-          (blocked) => { this.bulkBlockedThisSync += blocked; },
+          (info) => {
+            this.bulkBlockedThisSync = {
+              ...info,
+              blocked: (this.bulkBlockedThisSync?.blocked ?? 0) + info.blocked,
+              device_id: meta.device_id,
+              device_label: meta.device_label ?? null,
+            };
+          },
         );
         break;
       case "history":

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -244,8 +244,20 @@ export interface SyncState {
   bytes_transferred: number;
   // Set when the mass-delete guard blocked an unusual peer deletion on the last sync
   // (and an auto-snapshot was saved). Cleared at the start of each sync. `blocked` is
-  // how many local bookmarks the guard refused to remove.
-  recovery_notice?: { at: string; blocked: number } | null;
+  // how many local bookmarks the guard refused to remove, out of `local_total`.
+  //
+  // Everything past `blocked` is optional because a notice written by an older build
+  // does not carry it, and this object is read back from storage. The device is the
+  // useful half: a bare count says 48 bookmarks without saying 48 of what, or which
+  // machine asked, and both are needed before anyone can decide to approve it (#18).
+  recovery_notice?: {
+    at: string;
+    blocked: number;
+    cap?: number;
+    local_total?: number;
+    device_id?: string;
+    device_label?: string | null;
+  } | null;
 }
 
 /**
@@ -321,7 +333,12 @@ export type ExtensionMessage =
   | { type: "RESTORE_SNAPSHOT"; payload: { name: string } }
   | { type: "DELETE_SNAPSHOT"; payload: { name: string } }
   | { type: "LIST_DEVICES" }
-  | { type: "FORGET_DEVICE"; payload: { device_id: string } };
+  | { type: "FORGET_DEVICE"; payload: { device_id: string } }
+  // "Yes, apply the deletion the guard blocked." One-shot: consumed by the next merge.
+  // `blocked` is the count the UI actually showed, not a number re-read in the worker:
+  // sync() clears recovery_notice as it starts, so a click landing mid-sync would have
+  // found nothing pending and refused. It also pins the approval to what the user saw.
+  | { type: "APPROVE_BULK_DELETE"; payload: { blocked: number } };
 
 /**
  * One device with files in the sync folder.

--- a/src/lib/utils/storage.ts
+++ b/src/lib/utils/storage.ts
@@ -115,6 +115,7 @@ export const KEYS = {
   RESOLVED_CONFLICTS: "konode_resolved_conflicts",
   CONFLICT_PACKETS: "konode_conflict_packets",
   RECOVERY_SNAPSHOT: "konode_recovery_snap",
+  BULK_DELETE_APPROVAL: "konode_bulk_delete_ok",
   SYNC_LOCK: "konode_sync_lock",
   GDRIVE_SESSION: "konode_gdrive_session",
   GDRIVE_FOLDER: "konode_gdrive_folder",
@@ -514,6 +515,31 @@ export async function getRecoverySnapshotTaken(): Promise<boolean> {
 
 export async function setRecoverySnapshotTaken(taken: boolean): Promise<void> {
   await set(KEYS.RECOVERY_SNAPSHOT, taken);
+}
+
+// The user's one-shot "yes, apply that deletion" from Settings → Activity.
+//
+// The percentage slider cannot express this. It tops out at 95%, so a peer clearing
+// nearly its whole tree stays blocked at every setting and the warning never clears
+// (#18) — and even where raising it does work, it permanently weakens the guard to wave
+// through a single event that has already happened.
+//
+// So the approval is a latch, not a threshold: set from the UI, consumed by the very
+// next merge that would otherwise block, and cleared as it is consumed. Nothing carries
+// over to the sync after it. The restore point is already on the backend before the
+// button can exist, which is what makes saying yes cheap.
+//
+// It stores the SIZE that was approved rather than a bare true, and the merge honours it
+// only for a deletion that size or smaller. A plain boolean left armed until the next
+// sync would wave through whatever arrived in the meantime, so approving "48 of your 49"
+// could have cashed out against a different and much larger deletion. 0 means none.
+
+export async function getBulkDeleteApproval(): Promise<number> {
+  return get<number>(KEYS.BULK_DELETE_APPROVAL, 0);
+}
+
+export async function setBulkDeleteApproval(maxBlocked: number): Promise<void> {
+  await set(KEYS.BULK_DELETE_APPROVAL, maxBlocked);
 }
 
 // ─── Sync lock (CO-4) ─────────────────────────────────────────────────────────

--- a/src/options/App.tsx
+++ b/src/options/App.tsx
@@ -358,6 +358,11 @@ export default function OptionsApp() {
   const [snapLoad, setSnapLoad] = useState<"loading" | "ok" | string>("loading");
   const [confirmRestore, setConfirmRestore] = useState<string | null>(null);
   const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
+  // Activity tab: the blocked-deletion card. Two-step, like Restore and Delete above —
+  // applying it removes bookmarks, so it does not hang off a single click.
+  const [confirmApply, setConfirmApply] = useState(false);
+  const [applyBusy, setApplyBusy] = useState(false);
+  const [applyMsg, setApplyMsg] = useState<string | null>(null);
 
   // Activity tab data (fetched once on mount; see the effect below).
   const [syncState, setSyncState] = useState<SyncState | null>(null);
@@ -647,6 +652,26 @@ export default function OptionsApp() {
     if (res.type === "SNAPSHOT_RESTORED") setSnapMsg(plural("opt_snap_restored", res.payload.restored));
     else if (res.type === "ERROR") setSnapMsg(res.payload);
     setSnapBusy(false);
+  };
+
+  // "Yes, apply the deletion the guard blocked." The service worker arms a one-shot
+  // approval and syncs bookmarks straight away, so the result is visible here rather
+  // than a minute later. Re-reads state afterwards: a successful apply clears the
+  // recovery notice, which is what makes this card go away.
+  const applyBlockedDeletion = async () => {
+    setApplyBusy(true); setApplyMsg(null); setConfirmApply(false);
+    const res = await sendMessage({
+      type: "APPROVE_BULK_DELETE",
+      payload: { blocked: syncState?.recovery_notice?.blocked ?? 0 },
+    });
+    if (res.type === "ERROR") setApplyMsg(res.payload);
+    const after = await sendMessage({ type: "GET_STATE" });
+    if (after.type === "STATE") setSyncState(after.payload);
+    try {
+      const r = await browser.storage.local.get(KEYS.AUDIT_LOG);
+      setAudit((r[KEYS.AUDIT_LOG] as AuditEntry[]) ?? []);
+    } catch { /* the log is a nicety here, not the point of the action */ }
+    setApplyBusy(false);
   };
 
   const deleteSnapshot = async (name: string) => {
@@ -1884,6 +1909,66 @@ export default function OptionsApp() {
                     </Fragment>
                   ))}
                 </div>
+
+                {/* ── Blocked deletion ──
+                    Shown only while one is pending. The popup banner has always sent
+                    people here, but until now the only thing waiting for them was a log
+                    line: the percentage slider tops out at 95%, so a peer clearing
+                    nearly its whole tree stayed blocked at every setting and the
+                    warning never cleared (#18). This is the way through it. */}
+                {syncState?.recovery_notice && (
+                  <div className="settings-section">
+                    <div className="settings-card-head">
+                      {t("opt_blocked_section")}
+                      <span className="head-sub">{t("opt_blocked_section_sub")}</span>
+                    </div>
+                    <div className="settings-row">
+                      <div className="settings-row-left">
+                        <div>
+                          {/* "48 of your 49" is the number that decides this, and a bare
+                              48 is not: a notice from an older build has no total, so it
+                              falls back to the count it does have rather than to "of 0". */}
+                          <div className="row-label">
+                            {syncState.recovery_notice.local_total != null
+                              ? plural("opt_blocked_headline", syncState.recovery_notice.blocked,
+                                  [String(syncState.recovery_notice.blocked), String(syncState.recovery_notice.local_total)])
+                              : plural("opt_blocked_count", syncState.recovery_notice.blocked)}
+                          </div>
+                          <div className="row-desc">
+                            {syncState.recovery_notice.device_label
+                              ? t("opt_blocked_from", syncState.recovery_notice.device_label)
+                              : t("opt_blocked_from_unknown")}{" "}
+                            {t("opt_blocked_saved")}
+                          </div>
+                        </div>
+                      </div>
+                      {confirmApply ? (
+                        <div style={{ display: "flex", gap: 8, flexShrink: 0 }}>
+                          <button className="btn-secondary" onClick={() => setConfirmApply(false)} disabled={applyBusy}>{t("opt_cancel")}</button>
+                          <button className="btn-secondary" style={{ color: "var(--danger)", borderColor: "var(--danger)" }} onClick={applyBlockedDeletion} disabled={applyBusy}>
+                            {applyBusy ? <Loader2 size={12} className="spin" /> : <Trash2 size={12} />} {t("opt_blocked_confirm_apply")}
+                          </button>
+                        </div>
+                      ) : (
+                        <button className="btn-secondary" style={{ flexShrink: 0 }} onClick={() => setConfirmApply(true)} disabled={applyBusy}>
+                          <Trash2 size={12} /> {t("opt_blocked_apply")}
+                        </button>
+                      )}
+                    </div>
+                    <div className="settings-row">
+                      <div className="settings-row-left">
+                        <div className="row-desc">{t("opt_blocked_keep")}</div>
+                      </div>
+                    </div>
+                    {applyMsg && (
+                      <div className="settings-row">
+                        <div className="settings-row-left">
+                          <div className="error-row" role="alert"><AlertTriangle size={12} /> {applyMsg}</div>
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                )}
 
                 {/* ── Restore points ── */}
                 <div className="settings-section">


### PR DESCRIPTION
Reported by @klausbreyer in #16, whose screenshots turned out to contain three separate
problems.

## What was wrong

`boxbox` asked `imaecces` to delete 48 of its 49 bookmarks. The guard refused, saved a
restore point and showed the banner, which is the guard working. Everything after that
was not:

- **#18 There was no way to allow it.** The advice is to raise **Max bulk delete from a
  peer**, but the slider stops at 95%, which for 49 bookmarks is a cap of 46. The deletion
  was 48, so it stayed blocked at every position and the warning never cleared. Any peer
  deletion above 95% of the local tree was unreachable, and clearing the bookmarks on
  another machine is an ordinary thing to want.
- **#19 The log said it had happened.** `Merged +0 / -48` sat directly above the warning
  explaining that those 48 had been refused. The summary counted `toRemove.length`, which
  is what the peer asked for, not what the removal loop applied.
- **#20 It repeated forever.** That non-zero count also escalated the summary to a
  retained log level, so a merge that changed nothing wrote two kept entries every 60
  seconds, evicting the very warning the banner points at. The same mistake 1.3.0 fixed
  once for restore points, which got a latch that the log lines never did.

## What this does

**An explicit one-shot approval.** Settings → Activity grows a card while a deletion is
held back: how many out of how many, which device asked, and that the restore point is
already saved. Two-step button, like Restore and Delete beside it.

The latch stores the approved **size**, not a bare `true`, and the UI sends the number it
displayed rather than the worker re-reading state. A boolean left armed until the next
sync could have cashed out against whatever arrived in the meantime, and `sync()` clears
`recovery_notice` as it starts, so a click landing mid-sync would have found nothing
pending. The merge honours it only for a deletion that size or smaller, and spends it
either way, because an approval that no longer matches is stale rather than pending.

**The summary reports what it applied.** A `removed` counter, incremented by the loop that
actually calls `bookmarks.remove`. A blocked merge now logs `-0`, which drops it to `info`
on its own and takes half of #20 with it.

**The retained warning moved to the sync engine**, behind the latch that already decides
whether an incident is new. The merge still logs every cycle, to the console only. The
warning now names the proportion and the device, so it is actionable on its own.

**TROUBLESHOOTING.md** pointed at the slider, which is the one piece of advice that could
not work here. It now names both routes out, and says why the slider cannot always help.

## Verification

`npm run check` is green: 487 tests, no type errors, and the same 11 lint warnings as
`main` (stashed and re-run to confirm none are new). Five new tests cover the warning
firing once per incident, the `-0` after a blocked merge, the approval applying and being
spent, and the approval refusing a larger deletion than the one approved.

## Worth a look before merging

The four shipped locales are hand-translated here, because the i18n test requires every
English key in each of them. Translations normally arrive through Weblate as `chore(l10n)`
commits. The Hungarian I stand behind; German, Spanish and Chinese would benefit from a
translator's pass. Happy to drop those three and let Weblate fill them instead.

Also fixed in passing: the Hungarian popup notice said "Beállítások → Tevékenység" while
the tab itself is "Aktivitás", exactly the mismatch the English key's description warns
about.

Closes #18, closes #19, closes #20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
